### PR TITLE
finishon* flowops now terminate the thread rather than the whole run

### DIFF
--- a/flowop_library.c
+++ b/flowop_library.c
@@ -1041,17 +1041,7 @@ flowoplib_bwlimit(threadflow_t *threadflow, flowop_t *flowop)
 }
 
 /*
- * These flowops terminate a benchmark run when either the specified
- * number of bytes of I/O (flowoplib_finishonbytes) or the specified
- * number of I/O operations (flowoplib_finishoncount) have been generated.
- */
-
-
-/*
- * Stop filebench run when specified number of I/O bytes have been
- * transferred. Compares controlstats.fs_bytes with flowop->value,
- * and if greater returns 1, stopping the run, if not, returns 0
- * to continue running.
+ * Stop worker thread when specified number of I/O bytes have been transferred.
  */
 static int
 flowoplib_finishonbytes(threadflow_t *threadflow, flowop_t *flowop)
@@ -1091,7 +1081,7 @@ flowoplib_finishonbytes(threadflow_t *threadflow, flowop_t *flowop)
 	flowop_beginop(threadflow, flowop);
 	if (bytes_io > byte_lim) {
 		flowop_endop(threadflow, flowop, 0);
-		return (FILEBENCH_DONE);
+		return (FILEBENCH_NORSC);
 	}
 	flowop_endop(threadflow, flowop, 0);
 
@@ -1099,10 +1089,8 @@ flowoplib_finishonbytes(threadflow_t *threadflow, flowop_t *flowop)
 }
 
 /*
- * Stop filebench run when specified number of I/O operations have
- * been performed. Compares controlstats.fs_count with *flowop->value,
- * and if greater returns 1, stopping the run, if not, returns FILEBENCH_OK
- * to continue running.
+ * Stop worker thread when specified number of I/O operations have been
+ * transferred.
  */
 static int
 flowoplib_finishoncount(threadflow_t *threadflow, flowop_t *flowop)
@@ -1131,7 +1119,7 @@ flowoplib_finishoncount(threadflow_t *threadflow, flowop_t *flowop)
 	flowop_beginop(threadflow, flowop);
 	if (ops >= count) {
 		flowop_endop(threadflow, flowop, 0);
-		return (FILEBENCH_DONE);
+		return (FILEBENCH_NORSC);
 	}
 	flowop_endop(threadflow, flowop, 0);
 


### PR DESCRIPTION
Before this fix, the following workload

-------------------------------------------------------------------------------
set mode quit alldone

define fileset name=bigfileset,entries=10,path=/tmp,dirwidth=100,prealloc=0,filesize=0

define process name=filesequentialwrite, instances=1
{
 thread name=filewriter, memsize=4k, instances=1
 {
  flowop createfile name=create1, filesetname=bigfileset,fd=1
  flowop write name=write-file1, filesetname=bigfileset,iosize=4k,iters=262144,fd=1
  flowop closefile name=close1,fd=1
  flowop finishoncount name=finish, value=1
 }
 thread name=filewriter2,memsize=4k,instances=1
 {
  flowop createfile name=create2,filesetname=bigfileset,fd=2
  flowop write name=write-file2,filesetname=bigfileset,iosize=4k,iters=262144,fd=2
  flowop closefile name=close2,fd=2
  flowop finishoncount name=finish2,value=1
  }
 thread name=filewriter3,memsize=4k,instances=1
 {
  flowop createfile name=create3,filesetname=bigfileset,fd=2
  flowop write name=write-file3,filesetname=bigfileset,iosize=4k,iters=262144,fd=2
  flowop closefile name=close3,fd=2
  flowop finishoncount name=finish3,value=1
 }
}

run
-------------------------------------------------------------------------------

would create files of different sizes, though the expectation is that
the run finishes only after *all* threads done writing their
corresponding files to 1GB.

If one wants to finish the run as soon as the first thread is done
(older behaviour) she should just use "set mode quit firstdone" command.

Fixes issue #88