### PR TITLE
Installing cvar libraries in the right location

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+libdir = @libdir@/filebench
+
 SUBDIRS = workloads cvars
 
 # we depend on this lex & yacc generated file
@@ -26,4 +28,4 @@ if GCC_USED
 AM_CFLAGS = -Wall -Wno-unknown-pragmas
 endif
 
-DEFS = -D_REENTRANT -DYYDEBUG -DYY_NO_INPUT -DFBDATADIR=\"$(datadir)/filebench\" -D_LARGEFILE64_SOURCE -D_GNU_SOURCE
+DEFS = -D_REENTRANT -DYYDEBUG -DYY_NO_INPUT -DFBLIBDIR=\"$(libdir)\" -D_LARGEFILE64_SOURCE -D_GNU_SOURCE

--- a/cvars/Makefile.am
+++ b/cvars/Makefile.am
@@ -1,4 +1,4 @@
-libdir = $(datadir)/filebench/cvars
+libdir = @libdir@/filebench
 
 lib_LTLIBRARIES = libcvar-erlang.la \
 		  libcvar-exponential.la \

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -1537,7 +1537,7 @@ cvars_mode(struct fbparams *fbparams)
 
 	ipc_init();
 
-	ret = init_cvar_library_info(FBDATADIR "/cvars");
+	ret = init_cvar_library_info(FBLIBDIR);
 	if (ret)
 		filebench_shutdown(1);
 
@@ -1592,7 +1592,7 @@ master_mode(struct fbparams *fbparams) {
 	eventgen_init();
 
 	/* Initialize custom variables. */
-	ret = init_cvar_library_info(FBDATADIR "/cvars");
+	ret = init_cvar_library_info(FBLIBDIR);
 	if (ret)
 		filebench_shutdown(1);
 

--- a/workloads/Makefile.am
+++ b/workloads/Makefile.am
@@ -1,4 +1,4 @@
-workloadsdir=$(datadir)/filebench/workloads
+workloadsdir = @datadir@/filebench/workloads
 
 workloads_DATA = compflow_demo.f \
 	copyfiles.f \


### PR DESCRIPTION
Architecture-dependent files, like libraries, should
go to libdir. With this change "--libdir" and "--datadir"
configure options are now also supported.

Closes #85.