### PR TITLE
Generalize fsplug interface, several small cleanups

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,17 @@ filebench_SOURCES = eventgen.c fb_avl.c fb_localfs.c \
 		    fbtime.c fbtime.h \
 		    fb_cvar.c fb_cvar.h aslr.c aslr.h \
 		    cvars/mtwist/mtwist.c cvars/mtwist/mtwist.h
+filebench_LDFLAGS = -export-dynamic
+
+# We're going to build fb_localfs.c into a library as well; this means
+# building it both with and without libtool, triggering
+# an autoconf issue as documented at
+# https://www.gnu.org/software/automake/manual/html_node/Objects-created-both-with-libtool-and-without.html
+#
+# The recommended fix there is per-target flags.
+lib_LTLIBRARIES = libfb_localfs.la
+libfb_localfs_la_SOURCES = fb_localfs.c
+libfb_localfs_la_CFLAGS = $(AM_CFLAGS)
 
 EXTRA_DIST = LICENSE
 

--- a/README_COND_COMP
+++ b/README_COND_COMP
@@ -152,7 +152,7 @@ HAVE_PREAD64
 	On FreeBSD function pread64() is not available.
 	So we use refular pread() instead.
 
-HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP
+HAVE_PTHREAD_MUTEXATTR_SETROBUST
 
 	 Use robust mutexes if available.
 

--- a/README_COND_COMP
+++ b/README_COND_COMP
@@ -174,11 +174,6 @@ HAVE_SHM_SHARE_MMU
 	SHM_SHARE_MMU flag for shmat() is defined on Solaris.
 	Use it, if possible.
 
-HAVE_SIGIGNORE
-
-	On FreeBSD sigignore is not available, so we emulate
-	it via sigaction()
-
 HAVE_SIGSEND
 
 	Solaris has sigsend() syscall that allows to

--- a/README_COND_COMP
+++ b/README_COND_COMP
@@ -130,7 +130,7 @@ HAVE_OPEN64
 	On FreeBSD function open64() is not available. So we
 	use the refular open() instead.
 
-HAVE_PROCSCOPE_PTHREADS
+HAVE_PTHREAD_MUTEXATTR_SETPSHARED
 
 	If you have POSIX process scope threads, use them.
 
@@ -152,7 +152,7 @@ HAVE_PREAD64
 	On FreeBSD function pread64() is not available.
 	So we use refular pread() instead.
 
-HAVE_ROBUST_MUTEX
+HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP
 
 	 Use robust mutexes if available.
 

--- a/aslr.c
+++ b/aslr.c
@@ -23,7 +23,7 @@
 
 #if defined(HAVE_SYS_PERSONALITY_H) && defined(HAVE_ADDR_NO_RANDOMIZE)
 void
-linux_disable_aslr()
+linux_disable_aslr(void)
 {
 	int r;
 
@@ -34,7 +34,7 @@ linux_disable_aslr()
 }
 #else /* HAVE_SYS_PERSONALITY_H && HAVE_ADDR_NO_RANDOMIZE */
 void
-other_disable_aslr()
+other_disable_aslr(void)
 {
 	filebench_log(LOG_INFO, "Per-process disabling of ASLR is not "
 				"supported on this system. "

--- a/aslr.c
+++ b/aslr.c
@@ -21,7 +21,7 @@
 #include "filebench.h"
 #include "aslr.h"
 
-#if defined(HAVE_SYS_PERSONALITY_H) && defined(HAVE_ADDR_NO_RANDOMIZE)
+#if defined(HAVE_SYS_PERSONALITY_H) && defined(HAVE_DECL_ADDR_NO_RANDOMIZE)
 void
 linux_disable_aslr(void)
 {
@@ -32,7 +32,7 @@ linux_disable_aslr(void)
 	if (r == -1)
 		filebench_log(LOG_ERROR, "Could not disable ASLR");
 }
-#else /* HAVE_SYS_PERSONALITY_H && HAVE_ADDR_NO_RANDOMIZE */
+#else /* HAVE_SYS_PERSONALITY_H && HAVE_DECL_ADDR_NO_RANDOMIZE */
 void
 other_disable_aslr(void)
 {
@@ -44,4 +44,4 @@ other_disable_aslr(void)
 				"\"sysctl  kernel.randomize_va_space=0\" command. "
 				"(the change does not persist across reboots)");
 }
-#endif /* HAVE_SYS_PERSONALITY_H && HAVE_ADDR_NO_RANDOMIZE */
+#endif /* HAVE_SYS_PERSONALITY_H && HAVE_DECL_ADDR_NO_RANDOMIZE */

--- a/aslr.c
+++ b/aslr.c
@@ -16,12 +16,12 @@
  * functions should be added.
  */
 
-#include <sys/personality.h>
-
 #include "filebench.h"
 #include "aslr.h"
 
 #if defined(HAVE_SYS_PERSONALITY_H) && defined(HAVE_DECL_ADDR_NO_RANDOMIZE)
+#include <sys/personality.h>
+
 void
 linux_disable_aslr(void)
 {

--- a/aslr.c
+++ b/aslr.c
@@ -19,23 +19,38 @@
 #include "filebench.h"
 #include "aslr.h"
 
-#if defined(HAVE_SYS_PERSONALITY_H) && defined(HAVE_DECL_ADDR_NO_RANDOMIZE)
+#if defined(HAVE_SYS_PERSONALITY_H)
 #include <sys/personality.h>
+#elif defined(HAVE_LINUX_PERSONALITY_H)
+#include <linux/personality.h>
+#endif
 
-void
-linux_disable_aslr(void)
+/*
+ * Returns 0 if no action needs to be taken, 1 if the program must be
+ * re-exec()'d.
+ */
+int
+disable_aslr(void)
 {
+#if HAVE_DECL_ADDR_NO_RANDOMIZE
 	int r;
 
-	(void) personality(0xffffffff);
-	r = personality(0xffffffff | ADDR_NO_RANDOMIZE);
-	if (r == -1)
+	r = personality(0xffffffff);
+	/* Already disabled, no need to re-exec self */
+	if ((r != -1) && (r & ADDR_NO_RANDOMIZE))
+		return 0;
+
+	/* Toggle it on, then indicate need to re-exec() ourselves */
+	r = personality(r | ADDR_NO_RANDOMIZE);
+	if (r == -1) {
 		filebench_log(LOG_ERROR, "Could not disable ASLR");
-}
-#else /* HAVE_SYS_PERSONALITY_H && HAVE_DECL_ADDR_NO_RANDOMIZE */
-void
-other_disable_aslr(void)
-{
+		return 0;
+	}
+
+	return 1;
+
+#else /* HAVE_DECL_ADDR_NO_RANDOMIZE */
+
 	filebench_log(LOG_INFO, "Per-process disabling of ASLR is not "
 				"supported on this system. "
 				"For Filebench to work properly, "
@@ -43,5 +58,8 @@ other_disable_aslr(void)
 				"On Linux it can be achieved by "
 				"\"sysctl  kernel.randomize_va_space=0\" command. "
 				"(the change does not persist across reboots)");
+
+	return 0;
+
+#endif /* HAVE_DECL_ADDR_NO_RANDOMIZE */
 }
-#endif /* HAVE_SYS_PERSONALITY_H && HAVE_DECL_ADDR_NO_RANDOMIZE */

--- a/aslr.h
+++ b/aslr.h
@@ -10,7 +10,7 @@ linux_disable_aslr(void);
 static inline void
 disable_aslr(void)
 {
-	return linux_disable_aslr();
+	linux_disable_aslr();
 }
 #else /* HAVE_SYS_PERSONALITY_H && HAVE_DECL_ADDR_NO_RANDOMIZE */
 extern void
@@ -18,7 +18,7 @@ other_disable_aslr(void);
 
 static inline void
 disable_aslr(void) {
-	return other_disable_aslr();
+	other_disable_aslr();
 }
 #endif /* HAVE_SYS_PERSONALITY_H && HAVE_DECL_ADDR_NO_RANDOMIZE */
 

--- a/aslr.h
+++ b/aslr.h
@@ -5,19 +5,19 @@
 
 #if defined(HAVE_SYS_PERSONALITY_H) && defined(HAVE_ADDR_NO_RANDOMIZE)
 extern void
-linux_disable_aslr();
+linux_disable_aslr(void);
 
 static inline void
-disable_aslr()
+disable_aslr(void)
 {
 	return linux_disable_aslr();
 }
 #else /* HAVE_SYS_PERSONALITY_H && HAVE_ADDR_NO_RANDOMIZE */
 extern void
-other_disable_aslr();
+other_disable_aslr(void);
 
 static inline void
-disable_aslr() {
+disable_aslr(void) {
 	return other_disable_aslr();
 }
 #endif /* HAVE_SYS_PERSONALITY_H && HAVE_ADDR_NO_RANDOMIZE */

--- a/aslr.h
+++ b/aslr.h
@@ -3,7 +3,7 @@
 
 #include <filebench.h>
 
-#if defined(HAVE_SYS_PERSONALITY_H) && defined(HAVE_ADDR_NO_RANDOMIZE)
+#if defined(HAVE_SYS_PERSONALITY_H) && defined(HAVE_DECL_ADDR_NO_RANDOMIZE)
 extern void
 linux_disable_aslr(void);
 
@@ -12,7 +12,7 @@ disable_aslr(void)
 {
 	return linux_disable_aslr();
 }
-#else /* HAVE_SYS_PERSONALITY_H && HAVE_ADDR_NO_RANDOMIZE */
+#else /* HAVE_SYS_PERSONALITY_H && HAVE_DECL_ADDR_NO_RANDOMIZE */
 extern void
 other_disable_aslr(void);
 
@@ -20,6 +20,6 @@ static inline void
 disable_aslr(void) {
 	return other_disable_aslr();
 }
-#endif /* HAVE_SYS_PERSONALITY_H && HAVE_ADDR_NO_RANDOMIZE */
+#endif /* HAVE_SYS_PERSONALITY_H && HAVE_DECL_ADDR_NO_RANDOMIZE */
 
 #endif /* _ASLR_H */

--- a/aslr.h
+++ b/aslr.h
@@ -1,25 +1,6 @@
 #ifndef _ASLR_H
 #define _ASLR_H
 
-#include <filebench.h>
-
-#if defined(HAVE_SYS_PERSONALITY_H) && defined(HAVE_DECL_ADDR_NO_RANDOMIZE)
-extern void
-linux_disable_aslr(void);
-
-static inline void
-disable_aslr(void)
-{
-	linux_disable_aslr();
-}
-#else /* HAVE_SYS_PERSONALITY_H && HAVE_DECL_ADDR_NO_RANDOMIZE */
-extern void
-other_disable_aslr(void);
-
-static inline void
-disable_aslr(void) {
-	other_disable_aslr();
-}
-#endif /* HAVE_SYS_PERSONALITY_H && HAVE_DECL_ADDR_NO_RANDOMIZE */
+int disable_aslr(void);
 
 #endif /* _ASLR_H */

--- a/configure.ac
+++ b/configure.ac
@@ -155,7 +155,7 @@ AC_CHECK_LIB([m],[pow])
 AC_CHECK_LIB([pthread], [pthread_mutex_lock])
 # Use Sun's additional mutex functionality if available
 AC_CHECK_FUNCS([ \
-	pthread_mutexattr_setrobust_np \
+	pthread_mutexattr_setrobust \
 	pthread_mutexattr_setprotocol \
 	pthread_mutexattr_setpshared \
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -105,10 +105,6 @@ AC_CHECK_FUNCS([cftime])
 AC_CHECK_FUNC(
 	[_lwp_self],
         [ AC_DEFINE(HAVE_LWPS, 1, [ Define if you have lwps ])])
-# Check for sigignore() function: not available on FreeBSD
-AC_CHECK_FUNC(
-	[sigignore],
-        [ AC_DEFINE(HAVE_SIGIGNORE, 1, [ Define if you have sigignore ])])
 
 ####
 #### Check for more sophisticated functions

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ AC_CHECK_HEADERS([sys/socket.h])
 AC_CHECK_HEADERS([sys/statvfs.h])
 AC_CHECK_HEADERS([sys/time.h]) 
 AC_CHECK_HEADERS([sys/personality.h]) 
+AC_CHECK_HEADERS([linux/personality.h])
 
 ####
 #### Check for more sophisticated headers
@@ -372,7 +373,9 @@ AC_TRY_COMPILE([
 # Sometimes personality() function exists but ADDR_NO_RANDOMIZE is not defined
 # (e.g, in CentOS 5.11)
 #
-AC_CHECK_DECLS(ADDR_NO_RANDOMIZE,[],[],[#include <sys/personality.h>])
+AC_CHECK_DECLS(ADDR_NO_RANDOMIZE,[],[
+  AC_CHECK_DECLS(ADDR_NO_RANDOMIZE,[],[],[#include<linux/personality.h>])
+],[#include <sys/personality.h>])
 
 #
 # Configuring direct I/O. There are 3 main options:

--- a/configure.ac
+++ b/configure.ac
@@ -156,22 +156,12 @@ AC_CHECK_LIB(
 ])
 AC_CHECK_LIB([m],[pow])
 AC_CHECK_LIB([pthread], [pthread_mutex_lock])
-# Use Sun's robust mutexes if available
-AC_CHECK_LIB(
-	[pthread],
-	[pthread_mutexattr_setrobust_np],
-	[ AC_DEFINE(HAVE_ROBUST_MUTEX, 1, [ Define if you have robus POSIX mutexes ])]
-	)
 # Use Sun's additional mutex functionality if available
-AC_CHECK_LIB(
-	[pthread],
-	[pthread_mutexattr_setpshared],
-	[ AC_DEFINE(HAVE_PROCSCOPE_PTHREADS, 1, [ Define if you have POSIX process scope threads ])]
-	)
-AC_CHECK_LIB(
-	[pthread],
-	[pthread_mutexattr_setprotocol],
-        [ AC_DEFINE(HAVE_PTHREAD_MUTEXATTR_SETPROTOCOL, 1, [ Define if you have POSIX setprotocol ])])
+AC_CHECK_FUNCS([ \
+	pthread_mutexattr_setrobust_np \
+	pthread_mutexattr_setprotocol \
+	pthread_mutexattr_setpshared \
+])
 
 AC_CHECK_LIB([dl],[dlopen])
 
@@ -199,22 +189,7 @@ AC_TYPE_SIGNAL
 AC_TYPE_SIZE_T
 AC_STRUCT_TM
 
-# check for off64_t.
-# FreeBSD doesn't have off64_t because off_t et al are 64 bits,
-# even on 32-bit systems, and have been ever since the net4.4 release from UCB
-# (at least). Consequently, there isn't a separate set of interfaces for 32-bit
-# and 64-bit files or file systems, they're all 64-bit.
-AC_MSG_CHECKING(for off64_t)
-AC_TRY_COMPILE([
-	#define _LARGEFILE64_SOURCE
-	#include <sys/types.h>
-	],
-	[off64_t test;
-	],[
-	    AC_DEFINE(HAVE_OFF64_T, 1, [ Define if you have off64_t ])
-	    AC_MSG_RESULT(yes)
-	  ], AC_MSG_RESULT(no)
-)
+AC_CHECK_TYPES([off64_t])
 
 # check for boolean_t: Solaris defines it.
 AC_MSG_CHECKING(for boolean_t)
@@ -397,18 +372,7 @@ AC_TRY_COMPILE([
 # Sometimes personality() function exists but ADDR_NO_RANDOMIZE is not defined
 # (e.g, in CentOS 5.11)
 #
-AC_MSG_CHECKING(for ADDR_NO_RANDOMIZE)
-AC_TRY_COMPILE([
-	#include <sys/personality.h>
-	],
-	[
-		int ret;
-		ret = personality(0xffffffff | ADDR_NO_RANDOMIZE);
-	],[
-	    AC_DEFINE(HAVE_ADDR_NO_RANDOMIZE, 1, [ Define if you have ADDR_NO_RANDOMIZE. ])
-	    AC_MSG_RESULT(yes)
-	  ], AC_MSG_RESULT(no)
-)
+AC_CHECK_DECLS(ADDR_NO_RANDOMIZE,[],[],[#include <sys/personality.h>])
 
 #
 # Configuring direct I/O. There are 3 main options:

--- a/cvars/cvar-erlang.c
+++ b/cvars/cvar-erlang.c
@@ -122,7 +122,7 @@ void cvar_free_handle(void *handle, void (*cvar_free)(void *ptr))
 	cvar_free(handle);
 }
 
-const char *cvar_usage()
+const char *cvar_usage(void)
 {
 	int offset;
 
@@ -155,7 +155,7 @@ const char *cvar_usage()
 	return usage;
 }
 
-const char *cvar_version()
+const char *cvar_version(void)
 {
 	return VERSION;
 }

--- a/cvars/cvar-exponential.c
+++ b/cvars/cvar-exponential.c
@@ -108,7 +108,7 @@ void cvar_free_handle(void *handle, void (*cvar_free)(void *ptr))
 	cvar_free(handle);
 }
 
-const char *cvar_usage()
+const char *cvar_usage(void)
 {
 	int offset;
 
@@ -135,7 +135,7 @@ const char *cvar_usage()
 	return usage;
 }
 
-const char *cvar_version()
+const char *cvar_version(void)
 {
 	return VERSION;
 }

--- a/cvars/cvar-gamma.c
+++ b/cvars/cvar-gamma.c
@@ -242,7 +242,7 @@ void cvar_free_handle(void *handle, void (*cvar_free)(void *ptr))
 	cvar_free(handle);
 }
 
-const char *cvar_usage()
+const char *cvar_usage(void)
 {
 	int offset;
 
@@ -274,7 +274,7 @@ const char *cvar_usage()
 	return usage;
 }
 
-const char *cvar_version()
+const char *cvar_version(void)
 {
 	return VERSION;
 }

--- a/cvars/cvar-gamma.c
+++ b/cvars/cvar-gamma.c
@@ -116,19 +116,7 @@ default_src(unsigned short *xi)
 	return (drand48());
 }
 
-/*
- * Sample the gamma distributed random variable with gamma 'a' and
- * result mulitplier 'b', which is usually mean/gamma. Uses the default
- * drand48 random number generator as input
- */
-static double
-gamma_dist_knuth(double a, double b)
-{
-	if (a <= 1.0)
-		return (b * gamma_dist_knuth_algG(a, default_src, NULL));
-	else
-		return (b * gamma_dist_knuth_algA(a, default_src, NULL));
-}
+
 
 /*
  * Sample the gamma distributed random variable with gamma 'a' and
@@ -144,6 +132,17 @@ gamma_dist_knuth_src(double a, double b,
 		return (b * gamma_dist_knuth_algG(a, src, xi));
 	else
 		return (b * gamma_dist_knuth_algA(a, src, xi));
+}
+
+/*
+ * Sample the gamma distributed random variable with gamma 'a' and
+ * result mulitplier 'b', which is usually mean/gamma. Uses the default
+ * drand48 random number generator as input
+ */
+static double
+gamma_dist_knuth(double a, double b)
+{
+	return gamma_dist_knuth_src(a, b, default_src, NULL);
 }
 /*************************************************************/
 
@@ -216,8 +215,6 @@ out:
 
 int cvar_revalidate_handle(void *cvar_handle)
 {
-	handle_t *h = (handle_t *) cvar_handle;
-
 	return 0;
 }
 

--- a/cvars/cvar-lognormal.c
+++ b/cvars/cvar-lognormal.c
@@ -121,7 +121,7 @@ void cvar_free_handle(void *handle, void (*cvar_free)(void *ptr))
 	cvar_free(handle);
 }
 
-const char *cvar_usage()
+const char *cvar_usage(void)
 {
 	int offset;
 
@@ -154,7 +154,7 @@ const char *cvar_usage()
 	return usage;
 }
 
-const char *cvar_version()
+const char *cvar_version(void)
 {
 	return VERSION;
 }

--- a/cvars/cvar-normal.c
+++ b/cvars/cvar-normal.c
@@ -109,7 +109,7 @@ void cvar_free_handle(void *handle, void (*cvar_free)(void *ptr))
 	cvar_free(handle);
 }
 
-const char *cvar_usage()
+const char *cvar_usage(void)
 {
 	int offset;
 
@@ -142,7 +142,7 @@ const char *cvar_usage()
 	return usage;
 }
 
-const char *cvar_version()
+const char *cvar_version(void)
 {
 	return VERSION;
 }

--- a/cvars/cvar-triangular.c
+++ b/cvars/cvar-triangular.c
@@ -132,7 +132,7 @@ void cvar_free_handle(void *handle, void (*cvar_free)(void *ptr))
 	cvar_free(handle);
 }
 
-const char *cvar_usage()
+const char *cvar_usage(void)
 {
 	int offset;
 
@@ -169,7 +169,7 @@ const char *cvar_usage()
 	return usage;
 }
 
-const char *cvar_version()
+const char *cvar_version(void)
 {
 	return VERSION;
 }

--- a/cvars/cvar-uniform.c
+++ b/cvars/cvar-uniform.c
@@ -115,7 +115,7 @@ void cvar_free_handle(void *handle, void (*cvar_free)(void *ptr))
 	cvar_free(handle);
 }
 
-const char *cvar_usage()
+const char *cvar_usage(void)
 {
 	int offset;
 
@@ -147,7 +147,7 @@ const char *cvar_usage()
 	return usage;
 }
 
-const char *cvar_version()
+const char *cvar_version(void)
 {
 	return VERSION;
 }

--- a/cvars/cvar-weibull.c
+++ b/cvars/cvar-weibull.c
@@ -122,7 +122,7 @@ void cvar_free_handle(void *handle, void (*cvar_free)(void *ptr))
 	cvar_free(handle);
 }
 
-const char *cvar_usage()
+const char *cvar_usage(void)
 {
 	int offset;
 
@@ -155,7 +155,7 @@ const char *cvar_usage()
 	return usage;
 }
 
-const char *cvar_version()
+const char *cvar_version(void)
 {
 	return VERSION;
 }

--- a/cvars/cvar.h
+++ b/cvars/cvar.h
@@ -19,7 +19,7 @@
  * Return 0 on success and a non-zero error code on failure.
  */
 
-int cvar_module_init();
+int cvar_module_init(void);
 
 /*
  * Allocate a new custom variable handle. A handle is subsequently used to
@@ -84,7 +84,7 @@ void cvar_free_handle(void *cvar_handle, void (*cvar_free)(void *ptr));
  * to quit without invoking cvar_module_exit.
  */
 
-void cvar_module_exit();
+void cvar_module_exit(void);
 
 /*
  * Show usage, including information on the list of parameters supported and the
@@ -95,7 +95,7 @@ void cvar_module_exit();
  * Return a non-null, formatted string to be displayed on screen.
  */
 
-const char *cvar_usage();
+const char *cvar_usage(void);
 
 /*
  * Show version.
@@ -105,6 +105,6 @@ const char *cvar_usage();
  * Return a non-null version string.
  */
 
-const char *cvar_version();
+const char *cvar_version(void);
 
 #endif /* _CVAR_H */

--- a/cvars/cvar_tokens.c
+++ b/cvars/cvar_tokens.c
@@ -65,7 +65,7 @@ int tokenize(const char *parameters, const char parameter_delimiter,
 
 			if (key_start == key_end) {
 				cvar_log_error("Empty key at position %lu in parameter string "
-						"\"%s\"", (key_start - param)/sizeof(char) + 1,
+						"\"%s\"", ((unsigned long)(key_start - param))/sizeof(char) + 1,
 						parameters);
 				goto cleanup;
 			}

--- a/fb_cvar.c
+++ b/fb_cvar.c
@@ -81,6 +81,10 @@ init_cvar_library_info(const char *dirpath)
 		if (!strcmp(".", dirent->d_name) || !strcmp("..", dirent->d_name))
 			continue;
 
+		/* Restrict to appropriately-named libraries */
+		if (strncmp("libcvar-", dirent->d_name, 8))
+			continue;
+
 		direntlen = strlen(dirent->d_name);
 		if (strcmp(".so", dirent->d_name + direntlen - 3))
 			continue;

--- a/fb_cvar.c
+++ b/fb_cvar.c
@@ -204,7 +204,7 @@ static char
  * Returns 0 on success and non-zero on error.
  */
 int
-init_cvar_libraries()
+init_cvar_libraries(void)
 {
 	int count;
 	int ret = -1;
@@ -425,7 +425,7 @@ get_cvar_value(cvar_t *cvar)
  * Return 0 on success and a non-zero error code on failure.
  */
 int
-revalidate_cvar_handles()
+revalidate_cvar_handles(void)
 {
 	cvar_t *t;
 	cvar_library_t *cvar_lib;

--- a/fb_cvar.c
+++ b/fb_cvar.c
@@ -167,7 +167,7 @@ static char
 	else {
 		libname++;
 		/* Check for a malformed filename string. */
-		if (!libname) {
+		if (*libname == '\0') {
 			filebench_log(LOG_ERROR, "Malformed cvar library filename");
 			return NULL;
 		}

--- a/fb_cvar.h
+++ b/fb_cvar.h
@@ -59,7 +59,7 @@ typedef struct cvar_operations {
 	int (*cvar_revalidate_handle)(void *cvar_handle);
 	int (*cvar_next_value)(void *cvar_handle, double *value);
 	void (*cvar_free_handle)(void *cvar_handle, void (*cvar_free)(void *ptr));
-	void (*cvar_module_exit)();
+	void (*cvar_module_exit)(void);
 	const char *(*cvar_usage)(void);
 	const char *(*cvar_version)(void);
 } cvar_operations_t;
@@ -78,9 +78,9 @@ extern cvar_library_t **cvar_libraries;
 
 cvar_t * cvar_alloc(void);
 int init_cvar_library_info(const char *dirpath);
-int init_cvar_libraries();
+int init_cvar_libraries(void);
 int init_cvar_handle(cvar_t *cvar, const char *type, const char *parameters);
 double get_cvar_value(cvar_t *cvar);
-int revalidate_cvar_handles();
+int revalidate_cvar_handles(void);
 
 #endif /* _FB_CVAR_H */

--- a/fb_localfs.c
+++ b/fb_localfs.c
@@ -25,7 +25,6 @@
  * Portions Copyright 2008 Denis Cheng
  */
 
-#include "config.h"
 #include "filebench.h"
 #include "flowop.h"
 #include "threadflow.h" /* For aiolist definition */

--- a/fb_localfs.c
+++ b/fb_localfs.c
@@ -72,9 +72,9 @@ static int fb_lfs_unlink(char *);
 static ssize_t fb_lfs_readlink(const char *, char *, size_t);
 static int fb_lfs_mkdir(char *, int);
 static int fb_lfs_rmdir(char *);
-static DIR *fb_lfs_opendir(char *);
-static struct dirent *fb_lfs_readdir(DIR *);
-static int fb_lfs_closedir(DIR *);
+static struct fsplug_dir *fb_lfs_opendir(char *);
+static struct dirent *fb_lfs_readdir(struct fsplug_dir *);
+static int fb_lfs_closedir(struct fsplug_dir *);
 static int fb_lfs_fsync(fb_fdesc_t *);
 static int fb_lfs_stat(char *, struct stat64 *);
 static int fb_lfs_fstat(fb_fdesc_t *, struct stat64 *);
@@ -581,10 +581,10 @@ fb_lfs_recur_rm(char *path)
  * Does a posix opendir(), Returns a directory handle on success,
  * NULL on failure.
  */
-static DIR *
+static struct fsplug_dir *
 fb_lfs_opendir(char *path)
 {
-	return (opendir(path));
+	return (struct fsplug_dir *)(opendir(path));
 }
 
 /*
@@ -592,18 +592,18 @@ fb_lfs_opendir(char *path)
  * information on success, NULL on failure.
  */
 static struct dirent *
-fb_lfs_readdir(DIR *dirp)
+fb_lfs_readdir(struct fsplug_dir *dirp)
 {
-	return (readdir(dirp));
+	return (readdir((DIR*)dirp));
 }
 
 /*
  * Does a closedir() call.
  */
 static int
-fb_lfs_closedir(DIR *dirp)
+fb_lfs_closedir(struct fsplug_dir *dirp)
 {
-	return (closedir(dirp));
+	return (closedir((DIR*)dirp));
 }
 
 /*

--- a/fb_localfs.c
+++ b/fb_localfs.c
@@ -572,7 +572,7 @@ fb_lfs_recur_rm(char *path)
 	(void) snprintf(cmd, sizeof (cmd), "rm -rf %s", path);
 
 	/* We ignore system()'s return value */
-	if (system(cmd));
+	(void) system(cmd);
 	return;
 }
 

--- a/fb_random.c
+++ b/fb_random.c
@@ -72,7 +72,7 @@ fb_random64(uint64_t *randp, uint64_t max, uint64_t round, avd_t avd)
 	 */
 	max = max - round;
 
-	random_normalized = (double)random / UINT64_MAX;
+	random_normalized = (double)random / (double)UINT64_MAX;
 	random = random_normalized * max;
 
 	if (round) {

--- a/fb_random.c
+++ b/fb_random.c
@@ -103,7 +103,7 @@ fb_random32(uint32_t *randp,
  * Same as filebench_randomno64, but for probability [0-1].
  */
 static double
-fb_random_probability()
+fb_random_probability(void)
 {
 	uint64_t randnum;
 

--- a/fbtime.c
+++ b/fbtime.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "fbtime.h"
-#include "config.h"
 #include "filebench.h"
 
 /*

--- a/filebench.h
+++ b/filebench.h
@@ -157,16 +157,6 @@ void filebench_plugin_funcvecinit(void);
 #define	FILEBENCH_RANDMAX FILEBENCH_RANDMAX32
 #endif
 
-#ifndef HAVE_SIGIGNORE
-/* No sigignore on FreeBSD */
-static inline int sigignore(int sig) {
-        struct sigaction sa;
-        bzero(&sa, sizeof(sa));
-        sa.sa_handler = SIG_IGN;
-        return (sigaction(sig, &sa, NULL));
-}
-#endif
-
 #define	KB (1024LL)
 #define	MB (KB * KB)
 #define	GB (KB * MB)

--- a/filebench.h
+++ b/filebench.h
@@ -140,7 +140,6 @@ typedef unsigned int uint_t;
 
 extern pid_t my_pid;		/* this process' process id */
 extern procflow_t *my_procflow;	/* if slave process, procflow pointer */
-extern int errno;
 extern char *execname;
 
 void filebench_log __V((int level, const char *fmt, ...));

--- a/fileset.c
+++ b/fileset.c
@@ -171,7 +171,13 @@ fileset_mkdir(char *path, int mode)
 
 	/* Make the directories, from closest to root downwards. */
 	for (--i; i >= 0; i--) {
-		(void) FB_MKDIR(dirs[i], mode);
+		int code;
+		code = FB_MKDIR(dirs[i], mode);
+		if (code)
+			filebench_log(LOG_ERROR,
+				      "Failed to create directory path %s: %s",
+				      dirs[i], strerror(errno));
+
 		free(dirs[i]);
 	}
 

--- a/fileset.c
+++ b/fileset.c
@@ -1749,7 +1749,7 @@ fileset_checkraw(fileset_t *fileset)
  * fail.
  */
 int
-fileset_createsets()
+fileset_createsets(void)
 {
 	fileset_t *list;
 	int ret = 0;

--- a/fileset.c
+++ b/fileset.c
@@ -156,7 +156,7 @@ fileset_mkdir(char *path, int mode)
 	while (1) {
 		struct stat64 sb;
 
-		if (stat64(p, &sb) == 0)
+		if (FB_STAT(p, &sb) == 0)
 			break;
 		if (strlen(p) < 3)
 			break;
@@ -250,7 +250,7 @@ fileset_alloc_leafdir(filesetentry_t *entry)
 	filebench_log(LOG_DEBUG_IMPL, "Populated %s", entry->fse_path);
 
 	/* see if not reusing and this directory does not exist */
-	if (!((entry->fse_flags & FSE_REUSING) && (stat64(path, &sb) == 0))) {
+	if (!((entry->fse_flags & FSE_REUSING) && (FB_STAT(path, &sb) == 0))) {
 
 		/* No file or not reusing, so create */
 		if (FB_MKDIR(path, 0755) < 0) {
@@ -439,7 +439,7 @@ fileset_openfile(fb_fdesc_t *fdesc, fileset_t *fileset,
 	(void) trunc_dirname(dir);
 
 	/* If we are going to create a file, create the parent dirs */
-	if ((flag & O_CREAT) && (stat64(dir, &sb) != 0)) {
+	if ((flag & O_CREAT) && (FB_STAT(dir, &sb) != 0)) {
 		if (fileset_mkdir(dir, 0755) == FILEBENCH_ERROR)
 			return (FILEBENCH_ERROR);
 	}
@@ -1014,7 +1014,7 @@ fileset_create(fileset_t *fileset)
 	if (avd_get_bool(fileset->fs_trust_tree)) {
 		reusing = 1;
 	/* if exists and resusing, then don't create new */
-	} else if (((stat64(path, &sb) == 0)&& (strlen(path) > 3) &&
+	} else if (((FB_STAT(path, &sb) == 0)&& (strlen(path) > 3) &&
 	    (strlen(avd_get_str(fileset->fs_path)) > 2)) &&
 	    avd_get_bool(fileset->fs_reuse)) {
 		reusing = 1;
@@ -1727,7 +1727,7 @@ fileset_checkraw(fileset_t *fileset)
 	(void) fb_strlcpy(path, pathname, MAXPATHLEN);
 	(void) fb_strlcat(path, "/", MAXPATHLEN);
 	(void) fb_strlcat(path, setname, MAXPATHLEN);
-	if ((stat64(path, &sb) == 0) &&
+	if ((FB_STAT(path, &sb) == 0) &&
 	    ((sb.st_mode & S_IFMT) == S_IFBLK)) {
 		fileset->fs_attrs |= FILESET_IS_RAW_DEV;
 		if (!(fileset->fs_attrs & FILESET_IS_FILE)) {

--- a/fileset.h
+++ b/fileset.h
@@ -142,7 +142,7 @@ typedef struct fileset {
 	pthread_mutex_t	fs_histo_lock;	/* lock for incr of histo */
 } fileset_t;
 
-int fileset_createsets();
+int fileset_createsets(void);
 
 void fileset_delete_all_filesets(void);
 int fileset_openfile(fb_fdesc_t *fd, fileset_t *fileset,

--- a/flowop.c
+++ b/flowop.c
@@ -29,6 +29,7 @@
 #include <sys/lwp.h>
 #endif
 #include <fcntl.h>
+#include <dlfcn.h>
 #include "filebench.h"
 #include "flowop.h"
 #include "stats.h"
@@ -561,17 +562,27 @@ flowop_init(int ismaster)
 		flowoplib_flowinit();
 	}
 
-	switch (filebench_shm->shm_filesys_type) {
-	case LOCAL_FS_PLUG:
-		if (ismaster)
-			fb_lfs_newflowops();
-		fb_lfs_funcvecinit();
-		break;
-	case NFS3_PLUG:
-	case NFS4_PLUG:
-	case CIFS_PLUG:
-		break;
+	if (filebench_shm->shm_filesys_path[0] != '\0') {
+		void *fsplug_handle = dlopen(filebench_shm->shm_filesys_path, RTLD_LOCAL | RTLD_NOW);
+		if (fsplug_handle == NULL) {
+				filebench_log(LOG_ERROR, "Cannot load fsplug %s: %s\n",
+					filebench_shm->shm_filesys_path, dlerror());
+				filebench_shutdown(1);
+		}
+
+		fs_functions_vec = dlsym(fsplug_handle, FB_FSPLUG_MODULE_FUNC_S);
+		if (fs_functions_vec == NULL) {
+				filebench_log(LOG_ERROR, "fsplug is not what it claims? (%s)\n",
+					filebench_shm->shm_filesys_path);
+				filebench_shutdown(1);
+		}
 	}
+
+	if (ismaster && fs_functions_vec->fsp_init_master)
+		fs_functions_vec->fsp_init_master();
+
+	if (fs_functions_vec->fsp_init)
+		fs_functions_vec->fsp_init();
 }
 
 /*

--- a/flowop.c
+++ b/flowop.c
@@ -35,6 +35,8 @@
 #include "stats.h"
 #include "ioprio.h"
 
+static void *fsplug_handle = NULL;
+
 static flowop_t *flowop_define_common(threadflow_t *threadflow, char *name,
     flowop_t *inherit, flowop_t **flowoplist_hdp, int instance, int type);
 static int flowop_composite(threadflow_t *threadflow, flowop_t *flowop);
@@ -563,7 +565,7 @@ flowop_init(int ismaster)
 	}
 
 	if (filebench_shm->shm_filesys_path[0] != '\0') {
-		void *fsplug_handle = dlopen(filebench_shm->shm_filesys_path, RTLD_LOCAL | RTLD_NOW);
+		fsplug_handle = dlopen(filebench_shm->shm_filesys_path, RTLD_LOCAL | RTLD_NOW);
 		if (fsplug_handle == NULL) {
 				filebench_log(LOG_ERROR, "Cannot load fsplug %s: %s\n",
 					filebench_shm->shm_filesys_path, dlerror());
@@ -583,6 +585,15 @@ flowop_init(int ismaster)
 
 	if (fs_functions_vec->fsp_init)
 		fs_functions_vec->fsp_init();
+}
+
+void
+flowop_fini(void)
+{
+	if (fsplug_handle != NULL) {
+		dlclose(fsplug_handle);
+		fsplug_handle = NULL;
+	}
 }
 
 /*

--- a/flowop.h
+++ b/flowop.h
@@ -147,8 +147,4 @@ void flowop_printall(void);
 
 void flowop_init(int ismaster);
 
-/* Local file system specific */
-void fb_lfs_funcvecinit(void);
-void fb_lfs_newflowops(void);
-
 #endif	/* _FB_FLOWOP_H */

--- a/flowop.h
+++ b/flowop.h
@@ -146,5 +146,6 @@ flowop_t *flowop_new_composite_define(char *name);
 void flowop_printall(void);
 
 void flowop_init(int ismaster);
+void flowop_fini(void);
 
 #endif	/* _FB_FLOWOP_H */

--- a/flowop.h
+++ b/flowop.h
@@ -37,9 +37,9 @@ typedef struct flowop {
 	struct flowop	*fo_comp_fops;	/* List of flowops in composite fo */
 	var_t		*fo_lvar_list;	/* List of composite local vars */
 	struct threadflow *fo_thread;	/* Backpointer to thread */
-	int		(*fo_func)();	/* Method */
-	int		(*fo_init)();	/* Init Method */
-	void		(*fo_destruct)(); /* Destructor Method */
+	int		(*fo_func)(threadflow_t *, struct flowop *);	/* Method */
+	int		(*fo_init)(struct flowop *);	/* Init Method */
+	void		(*fo_destruct)(struct flowop *); /* Destructor Method */
 	int		fo_type;	/* Type */
 	int		fo_attrs;	/* Flow op attribute */
 	avd_t		fo_filename;	/* file/fileset name */
@@ -118,9 +118,9 @@ typedef struct flowop_proto {
 	int	fl_type;
 	int	fl_attrs;
 	char	*fl_name;
-	int	(*fl_init)();
-	int	(*fl_func)();
-	void	(*fl_destruct)();
+	int	(*fl_init)(flowop_t *);
+	int	(*fl_func)(threadflow_t *, flowop_t *);
+	void	(*fl_destruct)(flowop_t *);
 } flowop_proto_t;
 
 extern struct flowstats controlstats;
@@ -148,7 +148,7 @@ void flowop_printall(void);
 void flowop_init(int ismaster);
 
 /* Local file system specific */
-void fb_lfs_funcvecinit();
-void fb_lfs_newflowops();
+void fb_lfs_funcvecinit(void);
+void fb_lfs_newflowops(void);
 
 #endif	/* _FB_FLOWOP_H */

--- a/flowop_library.c
+++ b/flowop_library.c
@@ -417,7 +417,11 @@ flowoplib_iobufsetup(threadflow_t *threadflow, flowop_t *flowop,
     caddr_t *iobufp, fbint_t iosize)
 {
 	long memsize;
+#if defined(_LP64) || (__WORDSIZE == 64)
+	uint64_t memoffset;
+#else
 	size_t memoffset;
+#endif
 
 	if (iosize == 0) {
 		filebench_log(LOG_ERROR, "zero iosize for thread %s",

--- a/flowop_library.c
+++ b/flowop_library.c
@@ -2036,7 +2036,7 @@ flowoplib_listdir(threadflow_t *threadflow, flowop_t *flowop)
 {
 	fileset_t	*fileset;
 	filesetentry_t	*dir;
-	DIR		*dir_handle;
+	struct fsplug_dir	*dir_handle;
 	struct dirent	*direntp;
 	int		dir_bytes = 0;
 	int		ret;

--- a/flowop_library.c
+++ b/flowop_library.c
@@ -36,7 +36,6 @@
 #include <inttypes.h>
 #include <fcntl.h>
 #include <math.h>
-#include <dirent.h>
 
 #ifndef HAVE_SYSV_SEM
 #include <semaphore.h>
@@ -2037,7 +2036,7 @@ flowoplib_listdir(threadflow_t *threadflow, flowop_t *flowop)
 	fileset_t	*fileset;
 	filesetentry_t	*dir;
 	struct fsplug_dir	*dir_handle;
-	struct dirent	*direntp;
+	struct fsplug_dirent	dirent;
 	int		dir_bytes = 0;
 	int		ret;
 	char		full_path[MAXPATHLEN];
@@ -2069,9 +2068,8 @@ flowoplib_listdir(threadflow_t *threadflow, flowop_t *flowop)
 	}
 
 	/* read through the directory entries */
-	while ((direntp = FB_READDIR(dir_handle)) != NULL) {
-		dir_bytes += (strlen(direntp->d_name) +
-		    sizeof (struct dirent) - 1);
+	while (FB_READDIR(dir_handle,&dirent) == 0) {
+		dir_bytes += dirent.bytecost;
 	}
 
 	/* close the directory */

--- a/flowop_library.c
+++ b/flowop_library.c
@@ -554,7 +554,7 @@ flowoplib_read(threadflow_t *threadflow, flowop_t *flowop)
 		}
 		(void) flowop_endop(threadflow, flowop, ret);
 
-		if ((ret == 0))
+		if (ret == 0)
 			(void) FB_LSEEK(fdesc, 0, SEEK_SET);
 
 	} else {
@@ -570,7 +570,7 @@ flowoplib_read(threadflow_t *threadflow, flowop_t *flowop)
 		}
 		(void) flowop_endop(threadflow, flowop, ret);
 
-		if ((ret == 0))
+		if (ret == 0)
 			(void) FB_LSEEK(fdesc, 0, SEEK_SET);
 	}
 

--- a/flowop_library.c
+++ b/flowop_library.c
@@ -1219,7 +1219,9 @@ flowoplib_semblock(threadflow_t *threadflow, flowop_t *flowop)
 	struct sembuf sbuf[2];
 	int value = avd_get_int(flowop->fo_value);
 	int sys_semid;
+#ifdef HAVE_SEMTIMEDOP
 	struct timespec timeout;
+#endif
 
 	sys_semid = filebench_shm->shm_sys_semid;
 
@@ -1235,8 +1237,10 @@ flowoplib_semblock(threadflow_t *threadflow, flowop_t *flowop)
 	sbuf[1].sem_num = flowop->fo_semid_lw;
 	sbuf[1].sem_op = value * -1;
 	sbuf[1].sem_flg = 0;
+#ifdef HAVE_SEMTIMEDOP
 	timeout.tv_sec = 600;
 	timeout.tv_nsec = 0;
+#endif
 
 	if (avd_get_bool(flowop->fo_blocking))
 		(void) ipc_mutex_unlock(&flowop->fo_lock);
@@ -1340,10 +1344,12 @@ flowoplib_sempost(threadflow_t *threadflow, flowop_t *flowop)
 		struct sembuf sbuf[2];
 		int sys_semid;
 		int blocking;
+#ifdef HAVE_SEMTIMEDOP
+		struct timespec timeout;
+#endif
 #else
 		int i;
 #endif /* HAVE_SYSV_SEM */
-		struct timespec timeout;
 		int value = (int)avd_get_int(flowop->fo_value);
 
 		if (target->fo_instance == FLOW_MASTER) {
@@ -1366,8 +1372,10 @@ flowoplib_sempost(threadflow_t *threadflow, flowop_t *flowop)
 		sbuf[1].sem_num = target->fo_semid_hw;
 		sbuf[1].sem_op = value * -1;
 		sbuf[1].sem_flg = 0;
+#ifdef HAVE_SEMTIMEDOP
 		timeout.tv_sec = 600;
 		timeout.tv_nsec = 0;
+#endif
 
 		if (avd_get_bool(flowop->fo_blocking))
 			blocking = 1;

--- a/fsplug.h
+++ b/fsplug.h
@@ -50,6 +50,11 @@ typedef struct aiolist aiol_t;
 
 struct fsplug_dir; /* Opaque! */
 
+/* Approximate a dirent as far as we're concerned as a benchmark tool */
+struct fsplug_dirent {
+	int  bytecost;	/* Size of read operations */
+};
+
 /* Functions vector for file system plug-ins */
 typedef struct fsplug_func_s {
 	char fs_name[16];
@@ -70,7 +75,7 @@ typedef struct fsplug_func_s {
 	int (*fsp_mkdir)(char *, int);
 	int (*fsp_rmdir)(char *);
 	struct fsplug_dir *(*fsp_opendir)(char *);
-	struct dirent *(*fsp_readdir)(struct fsplug_dir *);
+	int (*fsp_readdir)(struct fsplug_dir *, struct fsplug_dirent *);
 	int (*fsp_closedir)(struct fsplug_dir *);
 	int (*fsp_fsync)(fb_fdesc_t *);
 	int (*fsp_stat)(char *, struct stat64 *);
@@ -118,8 +123,8 @@ extern fsplug_func_t *fs_functions_vec;
 #define	FB_OPENDIR(path) \
 	(*fs_functions_vec->fsp_opendir)(path)
 
-#define	FB_READDIR(dir) \
-	(*fs_functions_vec->fsp_readdir)(dir)
+#define	FB_READDIR(dir,dent) \
+	(*fs_functions_vec->fsp_readdir)(dir,dent)
 
 #define	FB_CLOSEDIR(dir) \
 	(*fs_functions_vec->fsp_closedir)(dir)

--- a/fsplug.h
+++ b/fsplug.h
@@ -48,6 +48,8 @@ typedef union fb_fdesc {
 
 typedef struct aiolist aiol_t;
 
+struct fsplug_dir; /* Opaque! */
+
 /* Functions vector for file system plug-ins */
 typedef struct fsplug_func_s {
 	char fs_name[16];
@@ -67,9 +69,9 @@ typedef struct fsplug_func_s {
 	ssize_t (*fsp_readlink)(const char *, char *, size_t);
 	int (*fsp_mkdir)(char *, int);
 	int (*fsp_rmdir)(char *);
-	DIR *(*fsp_opendir)(char *);
-	struct dirent *(*fsp_readdir)(DIR *);
-	int (*fsp_closedir)(DIR *);
+	struct fsplug_dir *(*fsp_opendir)(char *);
+	struct dirent *(*fsp_readdir)(struct fsplug_dir *);
+	int (*fsp_closedir)(struct fsplug_dir *);
 	int (*fsp_fsync)(fb_fdesc_t *);
 	int (*fsp_stat)(char *, struct stat64 *);
 	int (*fsp_fstat)(fb_fdesc_t *, struct stat64 *);

--- a/fsplug.h
+++ b/fsplug.h
@@ -30,16 +30,6 @@
 
 #include "filebench.h"
 
-/*
- * Type of file system client plug-in desired.
- */
-typedef enum fb_plugin_type {
-	LOCAL_FS_PLUG = 0,
-	NFS3_PLUG,
-	NFS4_PLUG,
-	CIFS_PLUG
-} fb_plugin_type_t;
-
 /* universal file descriptor for both local and nfs file systems */
 typedef union fb_fdesc {
 	int		fd_num;		/* OS file descriptor number */
@@ -58,6 +48,9 @@ struct fsplug_dirent {
 /* Functions vector for file system plug-ins */
 typedef struct fsplug_func_s {
 	char fs_name[16];
+	void (*fsp_init_master)(void);		/* Initialize once, in master process */
+	void (*fsp_init)(void);				/* Initialize in all processes */
+
 	int (*fsp_freemem)(fb_fdesc_t *, off64_t);
 	int (*fsp_open)(fb_fdesc_t *, char *, int, int);
 	int (*fsp_pread)(fb_fdesc_t *, caddr_t, fbint_t, off64_t);
@@ -84,6 +77,12 @@ typedef struct fsplug_func_s {
 	void (*fsp_recur_rm)(char *);
 } fsplug_func_t;
 
+#define FB_FSPLUG_MODULE_FUNC_S	"fsplug_funcs"
+
+/*
+ * The current functions vector; statically initialized to that of
+ * fb_localfs.c, but may be overwritten in flowop_init()
+ */
 extern fsplug_func_t *fs_functions_vec;
 
 /* Macros for calling functions */

--- a/ipc.c
+++ b/ipc.c
@@ -478,7 +478,7 @@ preallocated_entries(int obj_type)
 		break;
 	case FILEBENCH_AVD:
 		entries = sizeof(filebench_shm->shm_avd_ptrs)
-						/ sizeof(avd_t);
+						/ sizeof(struct avd);
 		break;
 	case FILEBENCH_RANDDIST:
 		entries = sizeof(filebench_shm->shm_randdist)

--- a/ipc.c
+++ b/ipc.c
@@ -63,16 +63,16 @@ ipc_mutex_lock(pthread_mutex_t *mutex)
 
 	error = pthread_mutex_lock(mutex);
 
-#ifdef HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETROBUST
 	if (error == EOWNERDEAD) {
-		if (pthread_mutex_consistent_np(mutex) != 0) {
+		if (pthread_mutex_consistent(mutex) != 0) {
 			filebench_log(LOG_FATAL, "mutex make consistent "
 			    "failed: %s", strerror(error));
 			return (-1);
 		}
 		return (0);
 	}
-#endif /* HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP */
+#endif /* HAVE_PTHREAD_MUTEXATTR_SETROBUST */
 
 	if (error != 0) {
 		filebench_log(LOG_FATAL, "mutex lock failed: %s",
@@ -92,16 +92,16 @@ ipc_mutex_unlock(pthread_mutex_t *mutex)
 
 	error = pthread_mutex_unlock(mutex);
 
-#ifdef HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETROBUST
 	if (error == EOWNERDEAD) {
-		if (pthread_mutex_consistent_np(mutex) != 0) {
+		if (pthread_mutex_consistent(mutex) != 0) {
 			filebench_log(LOG_FATAL, "mutex make consistent "
 			    "failed: %s", strerror(error));
 			return (-1);
 		}
 		return (0);
 	}
-#endif /* HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP */
+#endif /* HAVE_PTHREAD_MUTEXATTR_SETROBUST */
 
 	if (error != 0) {
 		filebench_log(LOG_FATAL, "mutex unlock failed: %s",
@@ -142,13 +142,13 @@ ipc_mutexattr_init(int mtx_type)
 	}
 #endif /* HAVE_PTHREAD_MUTEXATTR_SETPROTOCOL */
 #endif /* HAVE_PTHREAD_MUTEXATTR_SETPSHARED */
-#ifdef HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETROBUST
 	if (mtx_type & IPC_MUTEX_ROBUST) {
-		if (pthread_mutexattr_setrobust_np(mtx_attrp,
-		    PTHREAD_MUTEX_ROBUST_NP) != 0) {
+		if (pthread_mutexattr_setrobust(mtx_attrp,
+		    PTHREAD_MUTEX_ROBUST) != 0) {
 			filebench_log(LOG_ERROR,
 			    "cannot set mutex attr "
-			    "PTHREAD_MUTEX_ROBUST_NP on this platform");
+			    "PTHREAD_MUTEX_ROBUST on this platform");
 			filebench_shutdown(1);
 		}
 		if (pthread_mutexattr_settype(mtx_attrp,
@@ -160,7 +160,7 @@ ipc_mutexattr_init(int mtx_type)
 			filebench_shutdown(1);
 		}
 	}
-#endif /* HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP */
+#endif /* HAVE_PTHREAD_MUTEXATTR_SETROBUST */
 }
 
 /*

--- a/ipc.c
+++ b/ipc.c
@@ -274,7 +274,7 @@ ipc_seminit(void)
  * memory. It also uses ftok() to get a shared memory semaphore key for later
  * use in allocating shared semaphores.
  */
-void ipc_init(void)
+void ipc_init(fb_plugin_type_t plugtype)
 {
 	int shmfd;
 	char tmpbuf[MB];
@@ -332,6 +332,7 @@ void ipc_init(void)
 	filebench_shm->shm_string_ptr = &filebench_shm->shm_strings[0];
 	filebench_shm->shm_ptr = (char *)filebench_shm->shm_addr;
 	filebench_shm->shm_path_ptr = &filebench_shm->shm_filesetpaths[0];
+	filebench_shm->shm_filesys_type = plugtype;
 
 	(void) pthread_mutex_init(&filebench_shm->shm_fileset_lock,
 	    ipc_mutexattr(IPC_MUTEX_NORMAL));
@@ -374,8 +375,6 @@ void ipc_init(void)
 	filebench_shm->shm_dump_fd = -1;
 	filebench_shm->shm_eventgen_hz = 0;
 	filebench_shm->shm_id = -1;
-
-	filebench_shm->shm_filesys_type = LOCAL_FS_PLUG;
 }
 
 void

--- a/ipc.c
+++ b/ipc.c
@@ -38,6 +38,7 @@
 #include <sys/shm.h>
 #include "filebench.h"
 #include "fb_cvar.h"
+#include "utils.h"
 
 filebench_shm_t *filebench_shm = NULL;
 char *shmpath;
@@ -323,8 +324,8 @@ void ipc_init(char *fsplug)
 	 * Pass the name of the target filesystem, if not the local driver
 	 */
 	if (fsplug)
-		strncpy(filebench_shm->shm_filesys_path,fsplug,
-			sizeof (filebench_shm->shm_filesys_path)-1);
+		fb_strlcpy(filebench_shm->shm_filesys_path,fsplug,
+			   sizeof(filebench_shm->shm_filesys_path));
 
 	/*
 	 * First, initialize all the structures needed for the filebench_log()
@@ -708,7 +709,7 @@ ipc_stralloc(const char *string)
 		return (NULL);
 	}
 
-	(void) strncpy(allocstr, string, strlen(string));
+	memcpy(allocstr, string, strlen(string) + 1);
 
 	return (allocstr);
 }
@@ -737,7 +738,7 @@ ipc_pathalloc(char *path)
 		return (NULL);
 	}
 
-	(void) strncpy(allocpath, path, strlen(path));
+	memcpy(allocpath, path, strlen(path) + 1);
 
 	return (allocpath);
 }

--- a/ipc.c
+++ b/ipc.c
@@ -62,7 +62,7 @@ ipc_mutex_lock(pthread_mutex_t *mutex)
 
 	error = pthread_mutex_lock(mutex);
 
-#ifdef HAVE_ROBUST_MUTEX
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP
 	if (error == EOWNERDEAD) {
 		if (pthread_mutex_consistent_np(mutex) != 0) {
 			filebench_log(LOG_FATAL, "mutex make consistent "
@@ -71,7 +71,7 @@ ipc_mutex_lock(pthread_mutex_t *mutex)
 		}
 		return (0);
 	}
-#endif /* HAVE_ROBUST_MUTEX */
+#endif /* HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP */
 
 	if (error != 0) {
 		filebench_log(LOG_FATAL, "mutex lock failed: %s",
@@ -91,7 +91,7 @@ ipc_mutex_unlock(pthread_mutex_t *mutex)
 
 	error = pthread_mutex_unlock(mutex);
 
-#ifdef HAVE_ROBUST_MUTEX
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP
 	if (error == EOWNERDEAD) {
 		if (pthread_mutex_consistent_np(mutex) != 0) {
 			filebench_log(LOG_FATAL, "mutex make consistent "
@@ -100,7 +100,7 @@ ipc_mutex_unlock(pthread_mutex_t *mutex)
 		}
 		return (0);
 	}
-#endif /* HAVE_ROBUST_MUTEX */
+#endif /* HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP */
 
 	if (error != 0) {
 		filebench_log(LOG_FATAL, "mutex unlock failed: %s",
@@ -122,7 +122,7 @@ ipc_mutexattr_init(int mtx_type)
 
 	(void) pthread_mutexattr_init(mtx_attrp);
 
-#ifdef HAVE_PROCSCOPE_PTHREADS
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETPSHARED
 	if (pthread_mutexattr_setpshared(mtx_attrp,
 	    PTHREAD_PROCESS_SHARED) != 0) {
 		filebench_log(LOG_ERROR, "cannot set mutex attr "
@@ -140,8 +140,8 @@ ipc_mutexattr_init(int mtx_type)
 		}
 	}
 #endif /* HAVE_PTHREAD_MUTEXATTR_SETPROTOCOL */
-#endif /* HAVE_PROCSCOPE_PTHREADS */
-#ifdef HAVE_ROBUST_MUTEX
+#endif /* HAVE_PTHREAD_MUTEXATTR_SETPSHARED */
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP
 	if (mtx_type & IPC_MUTEX_ROBUST) {
 		if (pthread_mutexattr_setrobust_np(mtx_attrp,
 		    PTHREAD_MUTEX_ROBUST_NP) != 0) {
@@ -159,7 +159,7 @@ ipc_mutexattr_init(int mtx_type)
 			filebench_shutdown(1);
 		}
 	}
-#endif /* HAVE_ROBUST_MUTEX */
+#endif /* HAVE_PTHREAD_MUTEXATTR_SETROBUST_NP */
 }
 
 /*
@@ -197,14 +197,14 @@ ipc_condattr(void)
 			filebench_shutdown(1);
 		}
 		(void) pthread_condattr_init(condattr);
-#ifdef HAVE_PROCSCOPE_PTHREADS
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETPSHARED
 		if (pthread_condattr_setpshared(condattr,
 		    PTHREAD_PROCESS_SHARED) != 0) {
 			filebench_log(LOG_ERROR,
 			    "cannot set cond attr PROCESS_SHARED");
 //			filebench_shutdown(1);
 		}
-#endif /* HAVE_PROCSCOPE_PTHREADS */
+#endif /* HAVE_PTHREAD_MUTEXATTR_SETPSHARED */
 	}
 	return (condattr);
 }
@@ -226,14 +226,14 @@ ipc_rwlockattr(void)
 			filebench_shutdown(1);
 		}
 		(void) pthread_rwlockattr_init(rwlockattr);
-#ifdef HAVE_PROCSCOPE_PTHREADS
+#ifdef HAVE_PTHREAD_MUTEXATTR_SETPSHARED
 		if (pthread_rwlockattr_setpshared(rwlockattr,
 		    PTHREAD_PROCESS_SHARED) != 0) {
 			filebench_log(LOG_ERROR,
 			    "cannot set rwlock attr PROCESS_SHARED");
 //			filebench_shutdown(1);
 		}
-#endif /* HAVE_PROCSCOPE_PTHREADS */
+#endif /* HAVE_PTHREAD_MUTEXATTR_SETPSHARED */
 	}
 	return (rwlockattr);
 }

--- a/ipc.c
+++ b/ipc.c
@@ -274,7 +274,7 @@ ipc_seminit(void)
  * memory. It also uses ftok() to get a shared memory semaphore key for later
  * use in allocating shared semaphores.
  */
-void ipc_init(fb_plugin_type_t plugtype)
+void ipc_init(char *fsplug)
 {
 	int shmfd;
 	char tmpbuf[MB] = {0};
@@ -320,6 +320,13 @@ void ipc_init(fb_plugin_type_t plugtype)
 		 (char *)&filebench_shm->shm_marker - (char *)filebench_shm);
 
 	/*
+	 * Pass the name of the target filesystem, if not the local driver
+	 */
+	if (fsplug)
+		strncpy(filebench_shm->shm_filesys_path,fsplug,
+			sizeof (filebench_shm->shm_filesys_path)-1);
+
+	/*
 	 * First, initialize all the structures needed for the filebench_log()
 	 * function to work correctly with the log levels other than LOG_FATAL
 	 */
@@ -342,7 +349,6 @@ void ipc_init(fb_plugin_type_t plugtype)
 	filebench_shm->shm_string_ptr = &filebench_shm->shm_strings[0];
 	filebench_shm->shm_ptr = (char *)filebench_shm->shm_addr;
 	filebench_shm->shm_path_ptr = &filebench_shm->shm_filesetpaths[0];
-	filebench_shm->shm_filesys_type = plugtype;
 
 	(void) pthread_mutex_init(&filebench_shm->shm_fileset_lock,
 	    ipc_mutexattr(IPC_MUTEX_NORMAL));

--- a/ipc.c
+++ b/ipc.c
@@ -277,7 +277,7 @@ ipc_seminit(void)
 void ipc_init(fb_plugin_type_t plugtype)
 {
 	int shmfd;
-	char tmpbuf[MB];
+	char tmpbuf[MB] = {0};
 	key_t key;
 #ifdef HAVE_SEM_RMID
 	int sys_semid;

--- a/ipc.h
+++ b/ipc.h
@@ -223,7 +223,7 @@ typedef struct filebench_shm {
 	 * consequently use a lot of physical memory, while
 	 * in fact, we might not need so much memory later.
 	 */
-	int		shm_marker[0];
+	int		shm_marker;
 
 	/*
 	 * IPC shared memory pools. Allocated to users

--- a/ipc.h
+++ b/ipc.h
@@ -80,7 +80,7 @@
 /* 16 flowops per threadflow seems reasonable */
 #define	FILEBENCH_NFLOWOPS 		(16 * 1024)
 /* variables are not the only one that are specified
-   explicitly in the .f file. Some special 
+   explicitly in the .f file. Some special
    variables are used within FB itself. So, let's
    put this value to some save large value */
 #define	FILEBENCH_NVARIABLES		(1024)
@@ -100,7 +100,7 @@ typedef struct filebench_shm {
 	 * All fields down to shm_marker are set to zero during
 	 * filebench initialization in ipc_init() function.
 	 */
-	
+
 	/*
 	 * Global lists and locks for main Filebench objects:
 	 * filesets, procflows, threaflows, and flowops.
@@ -109,7 +109,7 @@ typedef struct filebench_shm {
 	pthread_mutex_t shm_fileset_lock;
 	procflow_t	*shm_procflowlist;
 	pthread_mutex_t shm_procflow_lock;
-	/* threadflow_t	*shm_threadflowlist; (this one is per procflow) */ 
+	/* threadflow_t	*shm_threadflowlist; (this one is per procflow) */
 	pthread_mutex_t shm_threadflow_lock;
 	flowop_t	*shm_flowoplist;
 	pthread_mutex_t shm_flowop_lock;
@@ -248,7 +248,7 @@ typedef struct filebench_shm {
 
 } filebench_shm_t;
 
-extern char shmpath[128];
+extern char *shmpath;
 
 extern void ipc_init(fb_plugin_type_t plugtype);
 extern int ipc_attach(void *shmaddr, char *shmpath);

--- a/ipc.h
+++ b/ipc.h
@@ -250,7 +250,7 @@ typedef struct filebench_shm {
 
 extern char shmpath[128];
 
-extern void ipc_init(void);
+extern void ipc_init(fb_plugin_type_t plugtype);
 extern int ipc_attach(void *shmaddr, char *shmpath);
 
 void *ipc_malloc(int type);

--- a/ipc.h
+++ b/ipc.h
@@ -205,7 +205,7 @@ typedef struct filebench_shm {
 	 * Type of plug-in file system client to use. Defaults to
 	 * local file system, which is type "0".
 	 */
-	fb_plugin_type_t shm_filesys_type;
+	char		shm_filesys_path[PATH_MAX];
 
 	/*
 	 * IPC shared memory pools allocation/deallocation control:
@@ -250,7 +250,7 @@ typedef struct filebench_shm {
 
 extern char *shmpath;
 
-extern void ipc_init(fb_plugin_type_t plugtype);
+extern void ipc_init(char *plugpath);
 extern int ipc_attach(void *shmaddr, char *shmpath);
 
 void *ipc_malloc(int type);

--- a/misc.c
+++ b/misc.c
@@ -138,7 +138,7 @@ fatal:
 		if (filebench_shm->shm_dump_fd != -1) {
 			(void) snprintf(buf, sizeof (buf), "%s\n", line);
 			/* We ignore the return value of write() */
-			if (write(filebench_shm->shm_dump_fd, buf, strlen(buf)));
+			(void) write(filebench_shm->shm_dump_fd, buf, strlen(buf));
 			(void) fsync(filebench_shm->shm_dump_fd);
 			(void) ipc_mutex_unlock(&filebench_shm->shm_msg_lock);
 			return;

--- a/misc.c
+++ b/misc.c
@@ -208,6 +208,7 @@ filebench_shutdown(int error) {
 	}
 
 	procflow_shutdown();
+	flowop_fini();
 
 	ipc_ismdelete();
 	ipc_fini();

--- a/misc.c
+++ b/misc.c
@@ -38,9 +38,6 @@
 #include "fsplug.h"
 #include "fbtime.h"
 
-/* File System functions vector */
-fsplug_func_t *fs_functions_vec;
-
 extern int lex_lineno;
 
 /*

--- a/misc.c
+++ b/misc.c
@@ -133,7 +133,8 @@ fatal:
 
 	if (level == LOG_DUMP) {
 		if (filebench_shm->shm_dump_fd != -1) {
-			(void) snprintf(buf, sizeof (buf), "%s\n", line);
+			(void) fb_strlcpy(buf, line, sizeof(buf));
+			(void) fb_strlcat(buf, "\n", sizeof(buf));
 			/* We ignore the return value of write() */
 			(void) write(filebench_shm->shm_dump_fd, buf, strlen(buf));
 			(void) fsync(filebench_shm->shm_dump_fd);

--- a/multi_client_sync.c
+++ b/multi_client_sync.c
@@ -98,18 +98,16 @@ int
 mc_sync_synchronize(int sync_point)
 {
 	char msg[MCS_MSGLENGTH];
-	int amnt;
 
 	(void) snprintf(msg, MCS_MSGLENGTH,
 	    "cmd=SYNC,id=xyzzy,name=%s,sample=%d\n",
 	    this_client_name, sync_point);
 	(void) send(mc_sync_sock_id, msg, strlen(msg), 0);
 
-	amnt = 0;
 	msg[0] = 0;
 
 	while (strchr(msg, '\n') == NULL)
-		amnt += recv(mc_sync_sock_id, msg, sizeof (msg), 0);
+		recv(mc_sync_sock_id, msg, sizeof (msg), 0);
 
 	filebench_log(LOG_INFO, "sync point %d succeeded!\n", sync_point);
 	return (FILEBENCH_OK);

--- a/multi_client_sync.c
+++ b/multi_client_sync.c
@@ -26,6 +26,7 @@
 
 #include "filebench.h"
 #include "multi_client_sync.h"
+#include "utils.h"
 #include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -49,7 +50,7 @@ mc_sync_open_sock(char *master_name, int master_port, char *my_name)
 	//int error_num;
 	//char buffer[MCS_MSGLENGTH];
 
-	(void) strncpy(this_client_name, my_name, MCS_NAMELENGTH);
+	(void) fb_strlcpy(this_client_name, my_name, MCS_NAMELENGTH);
 	if ((mc_sync_sock_id = socket(PF_INET, SOCK_STREAM, 0)) == -1) {
 		filebench_log(LOG_ERROR, "could not create a client socket");
 		return (FILEBENCH_ERROR);

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -130,8 +130,10 @@ static void parser_enable_lathist(cmd_t *cmd);
 %token FSC_SYSTEM FSC_EVENTGEN FSC_ECHO FSC_RUN FSC_PSRUN FSC_VERSION FSC_ENABLE
 %token FSC_DOMULTISYNC
 
-%token FSV_STRING FSV_VAL_POSINT FSV_VAL_NEGINT FSV_VAL_BOOLEAN FSV_VARIABLE 
-%token FSV_WHITESTRING FSV_RANDUNI FSV_RANDTAB FSV_URAND FSV_RAND48
+%token <sval> FSV_STRING FSV_VARIABLE FSV_WHITESTRING
+%token <ival> FSV_VAL_POSINT FSV_VAL_NEGINT
+%token <bval> FSV_VAL_BOOLEAN
+%token FSV_RANDUNI FSV_RANDTAB FSV_URAND FSV_RAND48
 
 %token FSE_FILE FSE_FILES FSE_FILESET FSE_PROC FSE_THREAD FSE_FLOWOP FSE_CVAR
 %token FSE_RAND FSE_MODE FSE_MULTI
@@ -150,14 +152,6 @@ static void parser_enable_lathist(cmd_t *cmd);
 %token FSA_CLIENT FSS_TYPE FSS_SEED FSS_GAMMA FSS_MEAN FSS_MIN FSS_SRC FSS_ROUND
 %token FSA_LVAR_ASSIGN FSA_ALLDONE FSA_FIRSTDONE FSA_TIMEOUT FSA_LATHIST
 %token FSA_NOREADAHEAD FSA_IOPRIO FSA_WRITEONLY FSA_PARAMETERS FSA_NOUSESTATS
-
-%type <ival> FSV_VAL_POSINT FSV_VAL_NEGINT
-%type <bval> FSV_VAL_BOOLEAN
-%type <sval> FSV_STRING FSV_WHITESTRING FSV_VARIABLE FSK_ASSIGN
-
-%type <ival> FSC_DEFINE FSC_SET FSC_RUN FSC_ENABLE FSC_PSRUN
-%type <ival> FSC_DOMULTISYNC
-%type <ival> FSE_FILE FSE_FILES FSE_PROC FSE_THREAD FSC_VERSION
 
 %type <sval> name
 
@@ -181,9 +175,8 @@ static void parser_enable_lathist(cmd_t *cmd);
 %type <list> whitevar_string whitevar_string_list
 %type <ival> attrs_define_thread attrs_flowop
 %type <ival> attrs_define_fileset attrs_define_file attrs_define_proc attrs_eventgen attrs_define_comp
-%type <ival> randvar_attr_name FSA_TYPE randtype_name
-%type <ival> randsrc_name FSA_RANDSRC em_attr_name
-%type <ival> FSS_TYPE FSS_SEED FSS_GAMMA FSS_MEAN FSS_MIN FSS_SRC
+%type <ival> randvar_attr_name randtype_name
+%type <ival> randsrc_name em_attr_name
 %type <ival> cvar_attr_name
 
 %type <rndtb>  probtabentry_list probtabentry

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -1575,7 +1575,7 @@ cvars_mode(struct fbparams *fbparams)
 static void
 parser_abort(int arg)
 {
-	(void) sigignore(SIGINT);
+	signal(SIGINT, SIG_IGN);
 	filebench_log(LOG_INFO, "Aborting...");
 	filebench_shutdown(1);
 }

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -1306,6 +1306,7 @@ var_int_val: FSV_VAL_POSINT
 "   -c             display supported cvar types\n" \
 "   -c [cvartype]  display options of the specific cvar type\n" \
 "   [-t fsplug]    Load filesystem plugin\n" \
+"   [-x wrapper]   Wrap workers with an external program\n" \
 "   -L <libdir>    set the library directory (for cvars, e.g.)\n\n"
 
 static void
@@ -1348,7 +1349,7 @@ init_fbparams(struct fbparams *fbparams)
 static int
 parse_options(int argc, char *argv[], struct fbparams *fbparams)
 {
-	const char cmd_options[] = "m:s:a:i:hf:c:L:t:";
+	const char cmd_options[] = "m:s:a:i:hf:c:L:t:x:";
 	int mode = FB_MODE_NONE;
 	int opt;
 
@@ -1397,6 +1398,11 @@ parse_options(int argc, char *argv[], struct fbparams *fbparams)
 			if (!optarg)
 				usage_exit(1, "Need type for -t");
 			fbparams->fsplug = optarg;
+			break;
+		case 'x':
+			if (!optarg)
+				usage_exit(1, "Need program for -x");
+			fbparams->execname = optarg;
 			break;
 		/* private parameters: when filebench calls itself */
 		case 'a':

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -1654,7 +1654,6 @@ master_mode(struct fbparams *fbparams) {
 static void
 init_common(void)
 {
-	disable_aslr();
 	my_pid = getpid();
 	fb_set_rlimit();
 }
@@ -1678,6 +1677,11 @@ main(int argc, char *argv[])
 {
 	struct fbparams fbparams;
 	int mode;
+
+	if (disable_aslr()) {
+		filebench_log(LOG_INFO, "ASLR now disabled; re-exec()ing self.");
+		execv(argv[0], argv);
+	}
 
 	/* parse_options() exits if detects wrong usage */
 	mode = parse_options(argc, argv, &fbparams);

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -2514,8 +2514,6 @@ parser_filebench_shutdown(cmd_t *cmd)
 {
 	int f_abort = filebench_shm->shm_f_abort;
 
-	ipc_fini();
-
 	if (f_abort == FILEBENCH_ABORT_ERROR)
 		filebench_shutdown(1);
 	else

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -69,7 +69,7 @@ static attr_t *alloc_attr(void);
 static attr_t *alloc_lvar_attr(var_t *var);
 static attr_t *get_attr(cmd_t *cmd, int64_t name);
 static void get_attr_lvars(cmd_t *cmd, flowop_t *flowop);
-static list_t *alloc_list();
+static list_t *alloc_list(void);
 static probtabent_t *alloc_probtabent(void);
 static void add_lvar_to_list(var_t *newlvar, var_t **lvar_list);
 
@@ -1619,7 +1619,7 @@ master_mode(struct fbparams *fbparams) {
 }
 
 static void
-init_common()
+init_common(void)
 {
 	disable_aslr();
 	my_pid = getpid();
@@ -3117,7 +3117,7 @@ get_attr_lvars(cmd_t *cmd, flowop_t *flowop)
  * returns a pointer to it. On failure, returns NULL.
  */
 static list_t *
-alloc_list()
+alloc_list(void)
 {
 	list_t *list;
 

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -28,6 +28,8 @@
 
 %{
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -2825,9 +2825,9 @@ parser_system(cmd_t *cmd)
 		    strerror(errno));
 		free(string);
 		filebench_shutdown(1);
+	} else {
+		free(string);
 	}
-
-	free(string);
 }
 
 /*

--- a/parser_gram.y
+++ b/parser_gram.y
@@ -1302,7 +1302,8 @@ var_int_val: FSV_VAL_POSINT
 "   -f <wmlscript> generate workload from the specified file\n" \
 "   -h             display this help message\n" \
 "   -c             display supported cvar types\n" \
-"   -c [cvartype]  display options of the specific cvar type\n\n"
+"   -c [cvartype]  display options of the specific cvar type\n" \
+"   -L <libdir>    set the library directory (for cvars, e.g.)\n\n"
 
 static void
 usage_exit(int ret, const char *msg)
@@ -1323,6 +1324,7 @@ struct fbparams {
 	char *shmpath;
 	int instance;
 	char *cvartype;
+	char *fblibdir;
 };
 
 static void
@@ -1330,6 +1332,7 @@ init_fbparams(struct fbparams *fbparams)
 {
 	memset(fbparams, 0, sizeof(*fbparams));
 	fbparams->instance = -1;
+	fbparams->fblibdir = FBLIBDIR;
 }
 
 #define FB_MODE_NONE		0
@@ -1341,7 +1344,7 @@ init_fbparams(struct fbparams *fbparams)
 static int
 parse_options(int argc, char *argv[], struct fbparams *fbparams)
 {
-	const char cmd_options[] = "m:s:a:i:hf:c:";
+	const char cmd_options[] = "m:s:a:i:hf:c:L:";
 	int mode = FB_MODE_NONE;
 	int opt;
 
@@ -1382,6 +1385,9 @@ parse_options(int argc, char *argv[], struct fbparams *fbparams)
 				usage_exit(1, "Too many options specified");
 			mode = FB_MODE_MASTER;
 			fbparams->fscriptname = optarg;
+			break;
+		case 'L':
+			fbparams->fblibdir = optarg;
 			break;
 		/* private parameters: when filebench calls itself */
 		case 'a':
@@ -1537,7 +1543,7 @@ cvars_mode(struct fbparams *fbparams)
 
 	ipc_init();
 
-	ret = init_cvar_library_info(FBLIBDIR);
+	ret = init_cvar_library_info(fbparams->fblibdir);
 	if (ret)
 		filebench_shutdown(1);
 
@@ -1592,7 +1598,7 @@ master_mode(struct fbparams *fbparams) {
 	eventgen_init();
 
 	/* Initialize custom variables. */
-	ret = init_cvar_library_info(FBLIBDIR);
+	ret = init_cvar_library_info(fbparams->fblibdir);
 	if (ret)
 		filebench_shutdown(1);
 

--- a/procflow.c
+++ b/procflow.c
@@ -106,7 +106,7 @@ procflow_createproc(procflow_t *procflow)
 		char syscmd[1024];
 #endif
 
-		(void) sigignore(SIGINT);
+		signal(SIGINT, SIG_IGN);
 		filebench_log(LOG_DEBUG_SCRIPT,
 		    "Starting %s-%d", procflow->pf_name,
 		    procflow->pf_instance);

--- a/procflow.c
+++ b/procflow.c
@@ -560,7 +560,7 @@ procflow_cleanup(procflow_t *procflow)
  * in which case it returns -1.
  */
 static int
-procflow_allstarted()
+procflow_allstarted(void)
 {
 	procflow_t *procflow = filebench_shm->shm_procflowlist;
 	int running_procs = 0;
@@ -787,7 +787,7 @@ procflow_define(char *name, avd_t instances)
  * system.
  */
 void
-proc_create()
+proc_create(void)
 {
 	filebench_shm->shm_1st_err = 0;
 	filebench_shm->shm_f_abort = FILEBENCH_OK;
@@ -828,7 +828,7 @@ proc_create()
  * It does not exit the filebench program though.
  */
 void
-proc_shutdown()
+proc_shutdown(void)
 {
 	filebench_log(LOG_INFO, "Shutting down processes");
 	procflow_shutdown();

--- a/procflow.c
+++ b/procflow.c
@@ -113,11 +113,12 @@ procflow_createproc(procflow_t *procflow)
 		/* Child */
 
 #ifdef USE_SYSTEM
-		(void) snprintf(syscmd, sizeof (syscmd), "%s -a %s -i %s -s %s",
+		(void) snprintf(syscmd, sizeof (syscmd), "%s -a %s -i %s -s %s -x %s",
 		    execname,
 		    procname,
 		    instance,
-		    shmaddr);
+		    shmaddr,
+		    execname);
 		if (system(syscmd) < 0) {
 			filebench_log(LOG_ERROR,
 			    "procflow exec proc failed: %s",
@@ -127,7 +128,8 @@ procflow_createproc(procflow_t *procflow)
 
 #else
 		if (execlp(execname, procname, "-a", procname, "-i",
-		    instance, "-s", shmaddr, "-m", shmpath, NULL) < 0) {
+		    instance, "-s", shmaddr, "-m", shmpath,
+		    "-x", execname, NULL) < 0) {
 			filebench_log(LOG_ERROR,
 			    "procflow exec proc failed: %s",
 			    strerror(errno));

--- a/procflow.c
+++ b/procflow.c
@@ -25,6 +25,8 @@
  * Portions Copyright 2008 Denis Cheng
  */
 
+#include "config.h"
+
 #include <signal.h>
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/vars.c
+++ b/vars.c
@@ -417,7 +417,7 @@ var_find_alloc(char *name)
 }
 
 int
-var_assign_boolean(char *name, boolean_t bool)
+var_assign_boolean(char *name, boolean_t val)
 {
 	var_t *var;
 
@@ -427,7 +427,7 @@ var_assign_boolean(char *name, boolean_t bool)
 		return -1;
 	}
 
-	VAR_SET_BOOL(var, bool);
+	VAR_SET_BOOL(var, val);
 
 	return 0;
 }
@@ -786,7 +786,7 @@ var_lvar_assign_var(char *name, char *src_name)
 }
 
 var_t *
-var_lvar_assign_boolean(char *name, boolean_t bool)
+var_lvar_assign_boolean(char *name, boolean_t val)
 {
 	var_t *var;
 
@@ -797,7 +797,7 @@ var_lvar_assign_boolean(char *name, boolean_t bool)
 		return NULL;
 	}
 
-	VAR_SET_BOOL(var, bool);
+	VAR_SET_BOOL(var, val);
 
 	return var;
 }

--- a/vars.h
+++ b/vars.h
@@ -160,13 +160,13 @@ typedef struct var {
 		(vp)->var_type = VAR_UNKNOWN; \
 	}
 
-avd_t avd_bool_alloc(boolean_t bool);
+avd_t avd_bool_alloc(boolean_t boolval);
 avd_t avd_int_alloc(uint64_t integer);
 avd_t avd_dbl_alloc(double integer);
 avd_t avd_str_alloc(char *string);
 avd_t avd_var_alloc(char *varname);
 
-int var_assign_boolean(char *name, boolean_t bool);
+int var_assign_boolean(char *name, boolean_t boolval);
 int var_assign_integer(char *name, uint64_t integer);
 int var_assign_double(char *name, double dbl);
 int var_assign_string(char *name, char *string);


### PR DESCRIPTION
Hallo!  Thanks for the neat tool. :)

As preparatory work for adding AuristorFS support to filebench, we made several small changes throughout the tree, none of which are AuristorFS-specific.  Hopefully, none of these are objectionable; indeed, many are stylistic and should induce no change in functionality (e.g., the autoconf changes and the move to "real" C prototypes, which just made it easier for us to build filebench).

The most significant changes are that we make directories and directory entries opaque when communicating to fs plugins, rather than assuming that they are backed by the corresponding libc structures.  This should also help when other fsplugs are added.

Thanks, preemptively, for your time.