### PR TITLE
fix off-by-one error in shm_bitmap

### DIFF
--- a/ipc.h
+++ b/ipc.h
@@ -65,7 +65,7 @@
 #define	FILEBENCH_RANDDIST		7
 #define FILEBENCH_CVAR			8
 #define FILEBENCH_CVAR_LIB_INFO		9
-#define	FILEBENCH_MAXTYPE		FILEBENCH_CVAR_LIB_INFO
+#define	FILEBENCH_MAXTYPE		(FILEBENCH_CVAR_LIB_INFO + 1)
 
 /*
  * The values below are selected by intuition: these limits


### PR DESCRIPTION
Hi, 

- shm_bitmap and shm_lastbitmapindex in filebench_shm_t have FILEBENCH_MAXTYPE entries.
- FILEBENCH_MAXTYPE is defined as FILEBENCH_CVAR_LIB_INFO in ipc.h.

So, invalid shm_bitmap[FILEBENCH_MAXTYPE] access occurs via ipc_malloc(FILEBENCH_CVAR_LIB_INFO) in alloc_cvar_lib_info.

