### PR TITLE
filebench: fix coredump problem with dirwidth=1

### DIFF
--- a/fileset.c
+++ b/fileset.c
@@ -1626,7 +1626,7 @@ fileset_populate(fileset_t *fileset)
 	 *	# ave size of file
 	 *	max size of file
 	 */
-	fileset->fs_meandepth = log(entries+leafdirs) / log(meandirwidth);
+	fileset->fs_meandepth = log(entries+leafdirs) / ((meandirwidth == 1) ? 0.1 : log(meandirwidth));
 
 	/* Has a random variable been supplied for dirdepth? */
 	if (fileset->fs_dirdepthrv) {


### PR DESCRIPTION
If we set dirwidth=1 when defining fileset, run
'filebench -f <wml-test>.f' will cause coredump.
Because we set fileset->fs_meandepth in fileset_populate() as follows,
$ fileset->fs_meandepth=log(entries+leafdirs)/log(meandirwidth).
where meandirwidth is equal to 1 as same with dirwidth in <wml-test>.f.
So fileset->fs_meandepth is set to inf, which will cause endless
recursion of fileset_populate_subdir(). Finally, coredump occurs.

Here, we will use a little bias (0.1) instead of log(1) when
meandirwidth is equal to 1.

Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>