### PR TITLE
Read/Write CDF/tail latency Support!

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,7 @@ filebench_SOURCES = eventgen.c fb_avl.c fb_localfs.c \
 		    ipc.h   multi_client_sync.h  parsertypes.h  stats.h \
 		    utils.h config.h fb_avl.h filebench.h flowop.h gamma_dist.h \
 		    misc.h procflow.h threadflow.h vars.h ioprio.h flag.h \
-		    fbtime.c fbtime.h \
+		    fbtime.c fbtime.h hdr_histogram.c \
 		    fb_cvar.c fb_cvar.h aslr.c aslr.h \
 		    cvars/mtwist/mtwist.c cvars/mtwist/mtwist.h
 

--- a/filebench.h
+++ b/filebench.h
@@ -124,6 +124,7 @@ typedef unsigned int uint_t;
 	#define pread64 pread
 #endif
 
+#include "hdr_histogram.h"
 #include "flag.h"
 #include "vars.h"
 #include "fb_cvar.h"

--- a/flowop.c
+++ b/flowop.c
@@ -196,12 +196,14 @@ flowop_endop(threadflow_t *threadflow, flowop_t *flowop, int64_t bytes)
 		flowop->fo_stats.fs_rcount++;
 		controlstats.fs_rbytes += bytes;
 		controlstats.fs_rcount++;
+		hdr_record_value(flowop->fo_read_hdr_histogram, ll_delay / 1000);
 	} else if (flowop->fo_attrs & FLOW_ATTR_WRITE) {
 		threadflow->tf_stats.fs_wbytes += bytes;
 		threadflow->tf_stats.fs_wcount++;
 		flowop->fo_stats.fs_wcount++;
 		controlstats.fs_wbytes += bytes;
 		controlstats.fs_wcount++;
+		hdr_record_value(flowop->fo_write_hdr_histogram, ll_delay / 1000);
 	}
 
 	if (filebench_shm->lathist_enabled)
@@ -754,6 +756,10 @@ flowop_define_common(threadflow_t *threadflow, char *name, flowop_t *inherit,
 	(void) strcpy(flowop->fo_name, name);
 	flowop->fo_instance = instance;
 
+	if (1 == instance) {
+		flowop_hdrs_init(flowop);
+	}
+
 	if (flowoplist_hdp == NULL)
 		return (flowop);
 
@@ -1146,4 +1152,76 @@ flowop_add_from_proto(flowop_proto_t *list, int nops)
 		flowop->fo_destruct = flproto->fl_destruct;
 		flowop->fo_attrs = flproto->fl_attrs;
 	}
+}
+
+void
+flowop_hdr_close(hdr_histogram_t *hdr_histogram)
+{
+	if (hdr_histogram) {
+		ipc_free(FILEBENCH_HDR_COUNTS, (char *)hdr_histogram->counts);
+		ipc_free(FILEBENCH_HDR_HISTOGRAM, (char *)hdr_histogram);
+	}
+}
+
+void
+flowop_hdrs_close(flowop_t *flowop)
+{
+	flowop_hdr_close(flowop->fo_read_hdr_histogram);
+	flowop_hdr_close(flowop->fo_write_hdr_histogram);
+}
+
+hdr_histogram_t *
+flowop_hdr_init()
+{
+	int64_t *hdr_counts = NULL;
+	struct hdr_histogram_bucket_config cfg;
+	hdr_histogram_t *hdr_histogram = NULL;
+
+	int r = hdr_calculate_bucket_config(1/* 1us */, INT64_C(60e6)/* 60s */, 2, &cfg);
+	if (r) {
+		return NULL;
+	}
+
+	hdr_counts = (int64_t *)ipc_malloc(FILEBENCH_HDR_COUNTS);
+	if (NULL == hdr_counts) {
+		filebench_log(LOG_ERROR, "flowop_hdr_init: Can't malloc hdr_counts");
+	}
+
+	hdr_histogram = (hdr_histogram_t *)ipc_malloc(FILEBENCH_HDR_HISTOGRAM);
+	if (NULL == hdr_histogram) {
+		filebench_log(LOG_ERROR, "flowop_hdr_init: Can't malloc hdr_histogram");
+		ipc_free(FILEBENCH_HDR_COUNTS, (char *)hdr_counts);
+		return NULL;
+	}
+
+	hdr_histogram->counts = hdr_counts;
+
+    hdr_init_preallocated(hdr_histogram, &cfg);
+
+	return hdr_histogram;
+}
+
+int
+flowop_hdrs_init(flowop_t *flowop)
+{
+	hdr_histogram_t *hdr_histogram = NULL;
+
+	if (NULL == flowop->fo_read_hdr_histogram) {
+		hdr_histogram = flowop_hdr_init();
+		if (NULL == hdr_histogram) {
+			return (FILEBENCH_NORSC);
+		}
+		flowop->fo_read_hdr_histogram = hdr_histogram;
+	}
+
+	if (NULL == flowop->fo_write_hdr_histogram) {
+		hdr_histogram = flowop_hdr_init();
+		if (NULL == hdr_histogram) {
+			flowop_hdr_close(flowop->fo_read_hdr_histogram);
+			return (FILEBENCH_NORSC);
+		}
+		flowop->fo_write_hdr_histogram = hdr_histogram;
+	}
+
+	return (FILEBENCH_OK);
 }

--- a/flowop.h
+++ b/flowop.h
@@ -66,6 +66,8 @@ typedef struct flowop {
 	avd_t		fo_fileindex;	/* Attr */
 	avd_t		fo_noreadahead; /* Attr */
 	struct flowstats	fo_stats;	/* Flow statistics */
+	hdr_histogram_t	*fo_read_hdr_histogram;		/* hdr_histogram for read */
+	hdr_histogram_t	*fo_write_hdr_histogram;	/* hdr_histogram for write */
 	pthread_cond_t	fo_cv;		/* Block/wakeup cv */
 	pthread_mutex_t	fo_lock;	/* Mutex around flowop */
 	void		*fo_private;	/* Flowop private scratch pad area */
@@ -150,5 +152,9 @@ void flowop_init(int ismaster);
 /* Local file system specific */
 void fb_lfs_funcvecinit();
 void fb_lfs_newflowops();
+
+hdr_histogram_t *flowop_hdr_init();
+int flowop_hdrs_init(flowop_t *flowop);
+void flowop_hdrs_close(flowop_t *flowop);
 
 #endif	/* _FB_FLOWOP_H */

--- a/flowop.h
+++ b/flowop.h
@@ -66,8 +66,7 @@ typedef struct flowop {
 	avd_t		fo_fileindex;	/* Attr */
 	avd_t		fo_noreadahead; /* Attr */
 	struct flowstats	fo_stats;	/* Flow statistics */
-	hdr_histogram_t	*fo_read_hdr_histogram;		/* hdr_histogram for read */
-	hdr_histogram_t	*fo_write_hdr_histogram;	/* hdr_histogram for write */
+	hdr_histogram_t	*fo_hdr_histogram;		/* hdr_histogram for read/write */
 	pthread_cond_t	fo_cv;		/* Block/wakeup cv */
 	pthread_mutex_t	fo_lock;	/* Mutex around flowop */
 	void		*fo_private;	/* Flowop private scratch pad area */
@@ -153,8 +152,6 @@ void flowop_init(int ismaster);
 void fb_lfs_funcvecinit();
 void fb_lfs_newflowops();
 
-hdr_histogram_t *flowop_hdr_init();
-int flowop_hdrs_init(flowop_t *flowop);
-void flowop_hdrs_close(flowop_t *flowop);
+hdr_histogram_t *fb_hdr_init();
 
 #endif	/* _FB_FLOWOP_H */

--- a/hdr_histogram.c
+++ b/hdr_histogram.c
@@ -1,0 +1,1121 @@
+/**
+ * hdr_histogram.c
+ * Written by Michael Barker and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <inttypes.h>
+
+#include "hdr_histogram.h"
+
+/*  ######   #######  ##     ## ##    ## ########  ######  */
+/* ##    ## ##     ## ##     ## ###   ##    ##    ##    ## */
+/* ##       ##     ## ##     ## ####  ##    ##    ##       */
+/* ##       ##     ## ##     ## ## ## ##    ##     ######  */
+/* ##       ##     ## ##     ## ##  ####    ##          ## */
+/* ##    ## ##     ## ##     ## ##   ###    ##    ##    ## */
+/*  ######   #######   #######  ##    ##    ##     ######  */
+
+static int32_t normalize_index(const struct hdr_histogram* h, int32_t index)
+{
+    int32_t normalized_index;
+    int32_t adjustment = 0;
+    if (h->normalizing_index_offset == 0)
+    {
+        return index;
+    }
+
+    normalized_index = index - h->normalizing_index_offset;
+
+    if (normalized_index < 0)
+    {
+        adjustment = h->counts_len;
+    }
+    else if (normalized_index >= h->counts_len)
+    {
+        adjustment = -h->counts_len;
+    }
+
+    return normalized_index + adjustment;
+}
+
+static int64_t counts_get_direct(const struct hdr_histogram* h, int32_t index)
+{
+    return h->counts[index];
+}
+
+static int64_t counts_get_normalised(const struct hdr_histogram* h, int32_t index)
+{
+    return counts_get_direct(h, normalize_index(h, index));
+}
+
+static void counts_inc_normalised(
+    struct hdr_histogram* h, int32_t index, int64_t value)
+{
+    int32_t normalised_index = normalize_index(h, index);
+    h->counts[normalised_index] += value;
+    h->total_count += value;
+}
+
+static void update_min_max(struct hdr_histogram* h, int64_t value)
+{
+    h->min_value = (value < h->min_value && value != 0) ? value : h->min_value;
+    h->max_value = (value > h->max_value) ? value : h->max_value;
+}
+
+/* ##     ## ######## #### ##       #### ######## ##    ## */
+/* ##     ##    ##     ##  ##        ##     ##     ##  ##  */
+/* ##     ##    ##     ##  ##        ##     ##      ####   */
+/* ##     ##    ##     ##  ##        ##     ##       ##    */
+/* ##     ##    ##     ##  ##        ##     ##       ##    */
+/* ##     ##    ##     ##  ##        ##     ##       ##    */
+/*  #######     ##    #### ######## ####    ##       ##    */
+
+static int64_t power(int64_t base, int64_t exp)
+{
+    int64_t result = 1;
+    while(exp)
+    {
+        result *= base; exp--;
+    }
+    return result;
+}
+
+#if defined(_MSC_VER)
+#   if defined(_WIN64)
+#       pragma intrinsic(_BitScanReverse64)
+#   else
+#       pragma intrinsic(_BitScanReverse)
+#   endif
+#endif
+
+static int32_t count_leading_zeros_64(int64_t value)
+{
+#if defined(_MSC_VER)
+    uint32_t leading_zero = 0;
+#if defined(_WIN64)
+    _BitScanReverse64(&leading_zero, value);
+#else
+    uint32_t high = value >> 32;
+    if  (_BitScanReverse(&leading_zero, high))
+    {
+        leading_zero += 32;
+    }
+    else
+    {
+        uint32_t low = value & 0x00000000FFFFFFFF;
+        _BitScanReverse(&leading_zero, low);
+    }
+#endif
+    return 63 - leading_zero; /* smallest power of 2 containing value */
+#else
+    return __builtin_clzll(value); /* smallest power of 2 containing value */
+#endif
+}
+
+static int32_t get_bucket_index(const struct hdr_histogram* h, int64_t value)
+{
+    int32_t pow2ceiling = 64 - count_leading_zeros_64(value | h->sub_bucket_mask); /* smallest power of 2 containing value */
+    return pow2ceiling - h->unit_magnitude - (h->sub_bucket_half_count_magnitude + 1);
+}
+
+static int32_t get_sub_bucket_index(int64_t value, int32_t bucket_index, int32_t unit_magnitude)
+{
+    return (int32_t)(value >> (bucket_index + unit_magnitude));
+}
+
+static int32_t counts_index(const struct hdr_histogram* h, int32_t bucket_index, int32_t sub_bucket_index)
+{
+    /* Calculate the index for the first entry in the bucket: */
+    /* (The following is the equivalent of ((bucket_index + 1) * subBucketHalfCount) ): */
+    int32_t bucket_base_index = (bucket_index + 1) << h->sub_bucket_half_count_magnitude;
+    /* Calculate the offset in the bucket: */
+    int32_t offset_in_bucket = sub_bucket_index - h->sub_bucket_half_count;
+    /* The following is the equivalent of ((sub_bucket_index  - subBucketHalfCount) + bucketBaseIndex; */
+    return bucket_base_index + offset_in_bucket;
+}
+
+static int64_t value_from_index(int32_t bucket_index, int32_t sub_bucket_index, int32_t unit_magnitude)
+{
+    return ((int64_t) sub_bucket_index) << (bucket_index + unit_magnitude);
+}
+
+int32_t counts_index_for(const struct hdr_histogram* h, int64_t value)
+{
+    int32_t bucket_index     = get_bucket_index(h, value);
+    int32_t sub_bucket_index = get_sub_bucket_index(value, bucket_index, h->unit_magnitude);
+
+    return counts_index(h, bucket_index, sub_bucket_index);
+}
+
+int64_t hdr_value_at_index(const struct hdr_histogram *h, int32_t index)
+{
+    int32_t bucket_index = (index >> h->sub_bucket_half_count_magnitude) - 1;
+    int32_t sub_bucket_index = (index & (h->sub_bucket_half_count - 1)) + h->sub_bucket_half_count;
+
+    if (bucket_index < 0)
+    {
+        sub_bucket_index -= h->sub_bucket_half_count;
+        bucket_index = 0;
+    }
+
+    return value_from_index(bucket_index, sub_bucket_index, h->unit_magnitude);
+}
+
+int64_t hdr_size_of_equivalent_value_range(const struct hdr_histogram* h, int64_t value)
+{
+    int32_t bucket_index     = get_bucket_index(h, value);
+    int32_t sub_bucket_index = get_sub_bucket_index(value, bucket_index, h->unit_magnitude);
+    int32_t adjusted_bucket  = (sub_bucket_index >= h->sub_bucket_count) ? (bucket_index + 1) : bucket_index;
+    return INT64_C(1) << (h->unit_magnitude + adjusted_bucket);
+}
+
+static int64_t size_of_equivalent_value_range_given_bucket_indices(
+    const struct hdr_histogram *h,
+    int32_t bucket_index,
+    int32_t sub_bucket_index)
+{
+    const int32_t adjusted_bucket  = (sub_bucket_index >= h->sub_bucket_count) ? (bucket_index + 1) : bucket_index;
+    return INT64_C(1) << (h->unit_magnitude + adjusted_bucket);
+}
+
+static int64_t lowest_equivalent_value(const struct hdr_histogram* h, int64_t value)
+{
+    int32_t bucket_index     = get_bucket_index(h, value);
+    int32_t sub_bucket_index = get_sub_bucket_index(value, bucket_index, h->unit_magnitude);
+    return value_from_index(bucket_index, sub_bucket_index, h->unit_magnitude);
+}
+
+static int64_t lowest_equivalent_value_given_bucket_indices(
+    const struct hdr_histogram *h,
+    int32_t bucket_index,
+    int32_t sub_bucket_index)
+{
+    return value_from_index(bucket_index, sub_bucket_index, h->unit_magnitude);
+}
+
+int64_t hdr_next_non_equivalent_value(const struct hdr_histogram *h, int64_t value)
+{
+    return lowest_equivalent_value(h, value) + hdr_size_of_equivalent_value_range(h, value);
+}
+
+static int64_t highest_equivalent_value(const struct hdr_histogram* h, int64_t value)
+{
+    return hdr_next_non_equivalent_value(h, value) - 1;
+}
+
+int64_t hdr_median_equivalent_value(const struct hdr_histogram *h, int64_t value)
+{
+    return lowest_equivalent_value(h, value) + (hdr_size_of_equivalent_value_range(h, value) >> 1);
+}
+
+static int64_t non_zero_min(const struct hdr_histogram* h)
+{
+    if (INT64_MAX == h->min_value)
+    {
+        return INT64_MAX;
+    }
+
+    return lowest_equivalent_value(h, h->min_value);
+}
+
+void hdr_reset_internal_counters(struct hdr_histogram* h)
+{
+    int min_non_zero_index = -1;
+    int max_index = -1;
+    int64_t observed_total_count = 0;
+    int i;
+
+    for (i = 0; i < h->counts_len; i++)
+    {
+        int64_t count_at_index;
+
+        if ((count_at_index = counts_get_direct(h, i)) > 0)
+        {
+            observed_total_count += count_at_index;
+            max_index = i;
+            if (min_non_zero_index == -1 && i != 0)
+            {
+                min_non_zero_index = i;
+            }
+        }
+    }
+
+    if (max_index == -1)
+    {
+        h->max_value = 0;
+    }
+    else
+    {
+        int64_t max_value = hdr_value_at_index(h, max_index);
+        h->max_value = highest_equivalent_value(h, max_value);
+    }
+
+    if (min_non_zero_index == -1)
+    {
+        h->min_value = INT64_MAX;
+    }
+    else
+    {
+        h->min_value = hdr_value_at_index(h, min_non_zero_index);
+    }
+
+    h->total_count = observed_total_count;
+}
+
+static int32_t buckets_needed_to_cover_value(int64_t value, int32_t sub_bucket_count, int32_t unit_magnitude)
+{
+    int64_t smallest_untrackable_value = ((int64_t) sub_bucket_count) << unit_magnitude;
+    int32_t buckets_needed = 1;
+    while (smallest_untrackable_value <= value)
+    {
+        if (smallest_untrackable_value > INT64_MAX / 2)
+        {
+            return buckets_needed + 1;
+        }
+        smallest_untrackable_value <<= 1;
+        buckets_needed++;
+    }
+
+    return buckets_needed;
+}
+
+/* ##     ## ######## ##     ##  #######  ########  ##    ## */
+/* ###   ### ##       ###   ### ##     ## ##     ##  ##  ##  */
+/* #### #### ##       #### #### ##     ## ##     ##   ####   */
+/* ## ### ## ######   ## ### ## ##     ## ########     ##    */
+/* ##     ## ##       ##     ## ##     ## ##   ##      ##    */
+/* ##     ## ##       ##     ## ##     ## ##    ##     ##    */
+/* ##     ## ######## ##     ##  #######  ##     ##    ##    */
+
+int hdr_calculate_bucket_config(
+        int64_t lowest_discernible_value,
+        int64_t highest_trackable_value,
+        int significant_figures,
+        struct hdr_histogram_bucket_config* cfg)
+{
+    int32_t sub_bucket_count_magnitude;
+    int64_t largest_value_with_single_unit_resolution;
+
+    if (lowest_discernible_value < 1 ||
+            significant_figures < 1 || 5 < significant_figures ||
+            lowest_discernible_value * 2 > highest_trackable_value)
+    {
+        return EINVAL;
+    }
+
+    cfg->lowest_discernible_value = lowest_discernible_value;
+    cfg->significant_figures = significant_figures;
+    cfg->highest_trackable_value = highest_trackable_value;
+
+    largest_value_with_single_unit_resolution = 2 * power(10, significant_figures);
+    sub_bucket_count_magnitude = (int32_t) ceil(log((double)largest_value_with_single_unit_resolution) / log(2));
+    cfg->sub_bucket_half_count_magnitude = ((sub_bucket_count_magnitude > 1) ? sub_bucket_count_magnitude : 1) - 1;
+
+    double unit_magnitude = log((double)lowest_discernible_value) / log(2);
+    if (INT32_MAX < unit_magnitude)
+    {
+        return EINVAL;
+    }
+
+    cfg->unit_magnitude = (int32_t) unit_magnitude;
+    cfg->sub_bucket_count      = (int32_t) pow(2, (cfg->sub_bucket_half_count_magnitude + 1));
+    cfg->sub_bucket_half_count = cfg->sub_bucket_count / 2;
+    cfg->sub_bucket_mask       = ((int64_t) cfg->sub_bucket_count - 1) << cfg->unit_magnitude;
+
+    if (cfg->unit_magnitude + cfg->sub_bucket_half_count_magnitude > 61)
+    {
+        return EINVAL;
+    }
+
+    cfg->bucket_count = buckets_needed_to_cover_value(highest_trackable_value, cfg->sub_bucket_count, (int32_t)cfg->unit_magnitude);
+    cfg->counts_len = (cfg->bucket_count + 1) * (cfg->sub_bucket_count / 2);
+
+    return 0;
+}
+
+void hdr_init_preallocated(struct hdr_histogram* h, struct hdr_histogram_bucket_config* cfg)
+{
+    h->lowest_discernible_value        = cfg->lowest_discernible_value;
+    h->highest_trackable_value         = cfg->highest_trackable_value;
+    h->unit_magnitude                  = (int32_t)cfg->unit_magnitude;
+    h->significant_figures             = (int32_t)cfg->significant_figures;
+    h->sub_bucket_half_count_magnitude = cfg->sub_bucket_half_count_magnitude;
+    h->sub_bucket_half_count           = cfg->sub_bucket_half_count;
+    h->sub_bucket_mask                 = cfg->sub_bucket_mask;
+    h->sub_bucket_count                = cfg->sub_bucket_count;
+    h->min_value                       = INT64_MAX;
+    h->max_value                       = 0;
+    h->normalizing_index_offset        = 0;
+    h->conversion_ratio                = 1.0;
+    h->bucket_count                    = cfg->bucket_count;
+    h->counts_len                      = cfg->counts_len;
+    h->total_count                     = 0;
+}
+
+int hdr_init(
+        int64_t lowest_discernible_value,
+        int64_t highest_trackable_value,
+        int significant_figures,
+        struct hdr_histogram** result)
+{
+    int64_t* counts;
+    struct hdr_histogram_bucket_config cfg;
+    struct hdr_histogram* histogram;
+
+    int r = hdr_calculate_bucket_config(lowest_discernible_value, highest_trackable_value, significant_figures, &cfg);
+    if (r)
+    {
+        return r;
+    }
+
+    counts = (int64_t*) calloc((size_t) cfg.counts_len, sizeof(int64_t));
+    if (!counts)
+    {
+        return ENOMEM;
+    }
+
+    histogram = (struct hdr_histogram*) calloc(1, sizeof(struct hdr_histogram));
+    if (!histogram)
+    {
+        free(counts);
+        return ENOMEM;
+    }
+
+    histogram->counts = counts;
+
+    hdr_init_preallocated(histogram, &cfg);
+    *result = histogram;
+
+    return 0;
+}
+
+void hdr_close(struct hdr_histogram* h)
+{
+    if (h) {
+	free(h->counts);
+	free(h);
+    }
+}
+
+int hdr_alloc(int64_t highest_trackable_value, int significant_figures, struct hdr_histogram** result)
+{
+    return hdr_init(1, highest_trackable_value, significant_figures, result);
+}
+
+/* reset a histogram to zero. */
+void hdr_reset(struct hdr_histogram *h)
+{
+     h->total_count=0;
+     h->min_value = INT64_MAX;
+     h->max_value = 0;
+     memset(h->counts, 0, (sizeof(int64_t) * h->counts_len));
+}
+
+size_t hdr_get_memory_size(struct hdr_histogram *h)
+{
+    return sizeof(struct hdr_histogram) + h->counts_len * sizeof(int64_t);
+}
+
+/* ##     ## ########  ########     ###    ######## ########  ######  */
+/* ##     ## ##     ## ##     ##   ## ##      ##    ##       ##    ## */
+/* ##     ## ##     ## ##     ##  ##   ##     ##    ##       ##       */
+/* ##     ## ########  ##     ## ##     ##    ##    ######    ######  */
+/* ##     ## ##        ##     ## #########    ##    ##             ## */
+/* ##     ## ##        ##     ## ##     ##    ##    ##       ##    ## */
+/*  #######  ##        ########  ##     ##    ##    ########  ######  */
+
+
+bool hdr_record_value(struct hdr_histogram* h, int64_t value)
+{
+    return hdr_record_values(h, value, 1);
+}
+
+bool hdr_record_values(struct hdr_histogram* h, int64_t value, int64_t count)
+{
+    int32_t counts_index;
+
+    if (value < 0)
+    {
+        return false;
+    }
+
+    counts_index = counts_index_for(h, value);
+
+    if (counts_index < 0 || h->counts_len <= counts_index)
+    {
+        return false;
+    }
+
+    counts_inc_normalised(h, counts_index, count);
+    update_min_max(h, value);
+
+    return true;
+}
+
+bool hdr_record_corrected_value(struct hdr_histogram* h, int64_t value, int64_t expected_interval)
+{
+    return hdr_record_corrected_values(h, value, 1, expected_interval);
+}
+
+bool hdr_record_corrected_values(struct hdr_histogram* h, int64_t value, int64_t count, int64_t expected_interval)
+{
+    int64_t missing_value;
+
+    if (!hdr_record_values(h, value, count))
+    {
+        return false;
+    }
+
+    if (expected_interval <= 0 || value <= expected_interval)
+    {
+        return true;
+    }
+
+    missing_value = value - expected_interval;
+    for (; missing_value >= expected_interval; missing_value -= expected_interval)
+    {
+        if (!hdr_record_values(h, missing_value, count))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+int64_t hdr_add(struct hdr_histogram* h, const struct hdr_histogram* from)
+{
+    struct hdr_iter iter;
+    int64_t dropped = 0;
+    hdr_iter_recorded_init(&iter, from);
+
+    while (hdr_iter_next(&iter))
+    {
+        int64_t value = iter.value;
+        int64_t count = iter.count;
+
+        if (!hdr_record_values(h, value, count))
+        {
+            dropped += count;
+        }
+    }
+
+    return dropped;
+}
+
+int64_t hdr_add_while_correcting_for_coordinated_omission(
+        struct hdr_histogram* h, struct hdr_histogram* from, int64_t expected_interval)
+{
+    struct hdr_iter iter;
+    int64_t dropped = 0;
+    hdr_iter_recorded_init(&iter, from);
+
+    while (hdr_iter_next(&iter))
+    {
+        int64_t value = iter.value;
+        int64_t count = iter.count;
+
+        if (!hdr_record_corrected_values(h, value, count, expected_interval))
+        {
+            dropped += count;
+        }
+    }
+
+    return dropped;
+}
+
+
+
+/* ##     ##    ###    ##       ##     ## ########  ######  */
+/* ##     ##   ## ##   ##       ##     ## ##       ##    ## */
+/* ##     ##  ##   ##  ##       ##     ## ##       ##       */
+/* ##     ## ##     ## ##       ##     ## ######    ######  */
+/*  ##   ##  ######### ##       ##     ## ##             ## */
+/*   ## ##   ##     ## ##       ##     ## ##       ##    ## */
+/*    ###    ##     ## ########  #######  ########  ######  */
+
+
+int64_t hdr_max(const struct hdr_histogram* h)
+{
+    if (0 == h->max_value)
+    {
+        return 0;
+    }
+
+    return highest_equivalent_value(h, h->max_value);
+}
+
+int64_t hdr_min(const struct hdr_histogram* h)
+{
+    if (0 < hdr_count_at_index(h, 0))
+    {
+        return 0;
+    }
+
+    return non_zero_min(h);
+}
+
+static int64_t get_value_from_idx_up_to_count(const struct hdr_histogram* h, int64_t count_at_percentile)
+{
+    int64_t count_to_idx = 0;
+
+    count_at_percentile = 0 < count_at_percentile ? count_at_percentile : 1;
+    for (int32_t idx = 0; idx < h->counts_len; idx++)
+    {
+        count_to_idx += h->counts[idx];
+        if (count_to_idx >= count_at_percentile)
+        {
+            return hdr_value_at_index(h, idx);
+        }
+    }
+
+    return 0;
+}
+
+
+int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile)
+{
+    double requested_percentile = percentile < 100.0 ? percentile : 100.0;
+    int64_t count_at_percentile =
+        (int64_t) (((requested_percentile / 100) * h->total_count) + 0.5);
+    int64_t value_from_idx = get_value_from_idx_up_to_count(h, count_at_percentile);
+    if (percentile == 0.0)
+    {
+        return lowest_equivalent_value(h, value_from_idx);
+    }
+    return highest_equivalent_value(h, value_from_idx);
+}
+
+int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percentiles, int64_t *values, size_t length)
+{
+    if (NULL == percentiles || NULL == values)
+    {
+        return EINVAL;
+    }
+
+    struct hdr_iter iter;
+    const int64_t total_count = h->total_count;
+    // to avoid allocations we use the values array for intermediate computation
+    // i.e. to store the expected cumulative count at each percentile
+    for (size_t i = 0; i < length; i++)
+    {
+        const double requested_percentile = percentiles[i] < 100.0 ? percentiles[i] : 100.0;
+        const int64_t count_at_percentile =
+        (int64_t) (((requested_percentile / 100) * total_count) + 0.5);
+        values[i] = count_at_percentile > 1 ? count_at_percentile : 1;
+    }
+
+    hdr_iter_init(&iter, h);
+    int64_t total = 0;
+    size_t at_pos = 0;
+    while (hdr_iter_next(&iter) && at_pos < length)
+    {
+        total += iter.count;
+        while (at_pos < length && total >= values[at_pos])
+        {
+            values[at_pos] = highest_equivalent_value(h, iter.value);
+            at_pos++;
+        }
+    }
+    return 0;
+}
+
+double hdr_mean(const struct hdr_histogram* h)
+{
+    struct hdr_iter iter;
+    int64_t total = 0;
+
+    hdr_iter_init(&iter, h);
+
+    while (hdr_iter_next(&iter))
+    {
+        if (0 != iter.count)
+        {
+            total += iter.count * hdr_median_equivalent_value(h, iter.value);
+        }
+    }
+
+    return (total * 1.0) / h->total_count;
+}
+
+double hdr_stddev(const struct hdr_histogram* h)
+{
+    double mean = hdr_mean(h);
+    double geometric_dev_total = 0.0;
+
+    struct hdr_iter iter;
+    hdr_iter_init(&iter, h);
+
+    while (hdr_iter_next(&iter))
+    {
+        if (0 != iter.count)
+        {
+            double dev = (hdr_median_equivalent_value(h, iter.value) * 1.0) - mean;
+            geometric_dev_total += (dev * dev) * iter.count;
+        }
+    }
+
+    return sqrt(geometric_dev_total / h->total_count);
+}
+
+bool hdr_values_are_equivalent(const struct hdr_histogram* h, int64_t a, int64_t b)
+{
+    return lowest_equivalent_value(h, a) == lowest_equivalent_value(h, b);
+}
+
+int64_t hdr_lowest_equivalent_value(const struct hdr_histogram* h, int64_t value)
+{
+    return lowest_equivalent_value(h, value);
+}
+
+int64_t hdr_count_at_value(const struct hdr_histogram* h, int64_t value)
+{
+    return counts_get_normalised(h, counts_index_for(h, value));
+}
+
+int64_t hdr_count_at_index(const struct hdr_histogram* h, int32_t index)
+{
+    return counts_get_normalised(h, index);
+}
+
+
+/* #### ######## ######## ########     ###    ########  #######  ########   ######  */
+/*  ##     ##    ##       ##     ##   ## ##      ##    ##     ## ##     ## ##    ## */
+/*  ##     ##    ##       ##     ##  ##   ##     ##    ##     ## ##     ## ##       */
+/*  ##     ##    ######   ########  ##     ##    ##    ##     ## ########   ######  */
+/*  ##     ##    ##       ##   ##   #########    ##    ##     ## ##   ##         ## */
+/*  ##     ##    ##       ##    ##  ##     ##    ##    ##     ## ##    ##  ##    ## */
+/* ####    ##    ######## ##     ## ##     ##    ##     #######  ##     ##  ######  */
+
+
+static bool has_buckets(struct hdr_iter* iter)
+{
+    return iter->counts_index < iter->h->counts_len;
+}
+
+static bool has_next(struct hdr_iter* iter)
+{
+    return iter->cumulative_count < iter->total_count;
+}
+
+static bool move_next(struct hdr_iter* iter)
+{
+    iter->counts_index++;
+
+    if (!has_buckets(iter))
+    {
+        return false;
+    }
+
+    iter->count = counts_get_normalised(iter->h, iter->counts_index);
+    iter->cumulative_count += iter->count;
+    const int64_t value = hdr_value_at_index(iter->h, iter->counts_index);
+    const int32_t bucket_index = get_bucket_index(iter->h, value);
+    const int32_t sub_bucket_index = get_sub_bucket_index(value, bucket_index, iter->h->unit_magnitude);
+    const int64_t leq = lowest_equivalent_value_given_bucket_indices(iter->h, bucket_index, sub_bucket_index);
+    const int64_t size_of_equivalent_value_range = size_of_equivalent_value_range_given_bucket_indices(
+        iter->h, bucket_index, sub_bucket_index);
+    iter->lowest_equivalent_value = leq;
+    iter->value = value;
+    iter->highest_equivalent_value = leq + size_of_equivalent_value_range - 1;
+    iter->median_equivalent_value = leq + (size_of_equivalent_value_range >> 1);
+
+    return true;
+}
+
+static int64_t peek_next_value_from_index(struct hdr_iter* iter)
+{
+    return hdr_value_at_index(iter->h, iter->counts_index + 1);
+}
+
+static bool next_value_greater_than_reporting_level_upper_bound(
+    struct hdr_iter *iter, int64_t reporting_level_upper_bound)
+{
+    if (iter->counts_index >= iter->h->counts_len)
+    {
+        return false;
+    }
+
+    return peek_next_value_from_index(iter) > reporting_level_upper_bound;
+}
+
+static bool basic_iter_next(struct hdr_iter *iter)
+{
+    if (!has_next(iter) || iter->counts_index >= iter->h->counts_len)
+    {
+        return false;
+    }
+
+    move_next(iter);
+
+    return true;
+}
+
+static void update_iterated_values(struct hdr_iter* iter, int64_t new_value_iterated_to)
+{
+    iter->value_iterated_from = iter->value_iterated_to;
+    iter->value_iterated_to = new_value_iterated_to;
+}
+
+static bool all_values_iter_next(struct hdr_iter* iter)
+{
+    bool result = move_next(iter);
+
+    if (result)
+    {
+        update_iterated_values(iter, iter->value);
+    }
+
+    return result;
+}
+
+void hdr_iter_init(struct hdr_iter* iter, const struct hdr_histogram* h)
+{
+    iter->h = h;
+
+    iter->counts_index = -1;
+    iter->total_count = h->total_count;
+    iter->count = 0;
+    iter->cumulative_count = 0;
+    iter->value = 0;
+    iter->highest_equivalent_value = 0;
+    iter->value_iterated_from = 0;
+    iter->value_iterated_to = 0;
+
+    iter->_next_fp = all_values_iter_next;
+}
+
+bool hdr_iter_next(struct hdr_iter* iter)
+{
+    return iter->_next_fp(iter);
+}
+
+/* ########  ######## ########   ######  ######## ##    ## ######## #### ##       ########  ######  */
+/* ##     ## ##       ##     ## ##    ## ##       ###   ##    ##     ##  ##       ##       ##    ## */
+/* ##     ## ##       ##     ## ##       ##       ####  ##    ##     ##  ##       ##       ##       */
+/* ########  ######   ########  ##       ######   ## ## ##    ##     ##  ##       ######    ######  */
+/* ##        ##       ##   ##   ##       ##       ##  ####    ##     ##  ##       ##             ## */
+/* ##        ##       ##    ##  ##    ## ##       ##   ###    ##     ##  ##       ##       ##    ## */
+/* ##        ######## ##     ##  ######  ######## ##    ##    ##    #### ######## ########  ######  */
+
+static bool percentile_iter_next(struct hdr_iter* iter)
+{
+    int64_t temp, half_distance, percentile_reporting_ticks;
+
+    struct hdr_iter_percentiles* percentiles = &iter->specifics.percentiles;
+
+    if (!has_next(iter))
+    {
+        if (percentiles->seen_last_value)
+        {
+            return false;
+        }
+
+        percentiles->seen_last_value = true;
+        percentiles->percentile = 100.0;
+
+        return true;
+    }
+
+    if (iter->counts_index == -1 && !basic_iter_next(iter))
+    {
+        return false;
+    }
+
+    do
+    {
+        double current_percentile = (100.0 * (double) iter->cumulative_count) / iter->h->total_count;
+        if (iter->count != 0 &&
+                percentiles->percentile_to_iterate_to <= current_percentile)
+        {
+            update_iterated_values(iter, highest_equivalent_value(iter->h, iter->value));
+
+            percentiles->percentile = percentiles->percentile_to_iterate_to;
+            temp = (int64_t)(log(100 / (100.0 - (percentiles->percentile_to_iterate_to))) / log(2)) + 1;
+            half_distance = (int64_t) pow(2, (double) temp);
+            percentile_reporting_ticks = percentiles->ticks_per_half_distance * half_distance;
+            percentiles->percentile_to_iterate_to += 100.0 / percentile_reporting_ticks;
+
+            return true;
+        }
+    }
+    while (basic_iter_next(iter));
+
+    return true;
+}
+
+void hdr_iter_percentile_init(struct hdr_iter* iter, const struct hdr_histogram* h, int32_t ticks_per_half_distance)
+{
+    iter->h = h;
+
+    hdr_iter_init(iter, h);
+
+    iter->specifics.percentiles.seen_last_value          = false;
+    iter->specifics.percentiles.ticks_per_half_distance  = ticks_per_half_distance;
+    iter->specifics.percentiles.percentile_to_iterate_to = 0.0;
+    iter->specifics.percentiles.percentile               = 0.0;
+
+    iter->_next_fp = percentile_iter_next;
+}
+
+static void format_line_string(char* str, size_t len, int significant_figures, format_type format)
+{
+#if defined(_MSC_VER)
+#define snprintf _snprintf
+#pragma warning(push)
+#pragma warning(disable: 4996)
+#endif
+    const char* format_str = "%s%d%s";
+
+    switch (format)
+    {
+        case CSV:
+            snprintf(str, len, format_str, "%.", significant_figures, "f,%f,%d,%.2f\n");
+            break;
+        case CLASSIC:
+            snprintf(str, len, format_str, "%12.", significant_figures, "f %12f %12d %12.2f\n");
+            break;
+        default:
+            snprintf(str, len, format_str, "%12.", significant_figures, "f %12f %12d %12.2f\n");
+    }
+#if defined(_MSC_VER)
+#undef snprintf
+#pragma warning(pop)
+#endif
+}
+
+
+/* ########  ########  ######   #######  ########  ########  ######## ########   */
+/* ##     ## ##       ##    ## ##     ## ##     ## ##     ## ##       ##     ##  */
+/* ##     ## ##       ##       ##     ## ##     ## ##     ## ##       ##     ##  */
+/* ########  ######   ##       ##     ## ########  ##     ## ######   ##     ##  */
+/* ##   ##   ##       ##       ##     ## ##   ##   ##     ## ##       ##     ##  */
+/* ##    ##  ##       ##    ## ##     ## ##    ##  ##     ## ##       ##     ##  */
+/* ##     ## ########  ######   #######  ##     ## ########  ######## ########   */
+
+
+static bool recorded_iter_next(struct hdr_iter* iter)
+{
+    while (basic_iter_next(iter))
+    {
+        if (iter->count != 0)
+        {
+            update_iterated_values(iter, iter->value);
+
+            iter->specifics.recorded.count_added_in_this_iteration_step = iter->count;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void hdr_iter_recorded_init(struct hdr_iter* iter, const struct hdr_histogram* h)
+{
+    hdr_iter_init(iter, h);
+
+    iter->specifics.recorded.count_added_in_this_iteration_step = 0;
+
+    iter->_next_fp = recorded_iter_next;
+}
+
+/* ##       #### ##    ## ########    ###    ########  */
+/* ##        ##  ###   ## ##         ## ##   ##     ## */
+/* ##        ##  ####  ## ##        ##   ##  ##     ## */
+/* ##        ##  ## ## ## ######   ##     ## ########  */
+/* ##        ##  ##  #### ##       ######### ##   ##   */
+/* ##        ##  ##   ### ##       ##     ## ##    ##  */
+/* ######## #### ##    ## ######## ##     ## ##     ## */
+
+
+static bool iter_linear_next(struct hdr_iter* iter)
+{
+    struct hdr_iter_linear* linear = &iter->specifics.linear;
+
+    linear->count_added_in_this_iteration_step = 0;
+
+    if (has_next(iter) ||
+        next_value_greater_than_reporting_level_upper_bound(
+            iter, linear->next_value_reporting_level_lowest_equivalent))
+    {
+        do
+        {
+            if (iter->value >= linear->next_value_reporting_level_lowest_equivalent)
+            {
+                update_iterated_values(iter, linear->next_value_reporting_level);
+
+                linear->next_value_reporting_level += linear->value_units_per_bucket;
+                linear->next_value_reporting_level_lowest_equivalent =
+                    lowest_equivalent_value(iter->h, linear->next_value_reporting_level);
+
+                return true;
+            }
+
+            if (!move_next(iter))
+            {
+                return true;
+            }
+
+            linear->count_added_in_this_iteration_step += iter->count;
+        }
+        while (true);
+    }
+
+    return false;
+}
+
+
+void hdr_iter_linear_init(struct hdr_iter* iter, const struct hdr_histogram* h, int64_t value_units_per_bucket)
+{
+    hdr_iter_init(iter, h);
+
+    iter->specifics.linear.count_added_in_this_iteration_step = 0;
+    iter->specifics.linear.value_units_per_bucket = value_units_per_bucket;
+    iter->specifics.linear.next_value_reporting_level = value_units_per_bucket;
+    iter->specifics.linear.next_value_reporting_level_lowest_equivalent = lowest_equivalent_value(h, value_units_per_bucket);
+
+    iter->_next_fp = iter_linear_next;
+}
+
+/* ##        #######   ######      ###    ########  #### ######## ##     ## ##     ## ####  ######  */
+/* ##       ##     ## ##    ##    ## ##   ##     ##  ##     ##    ##     ## ###   ###  ##  ##    ## */
+/* ##       ##     ## ##         ##   ##  ##     ##  ##     ##    ##     ## #### ####  ##  ##       */
+/* ##       ##     ## ##   #### ##     ## ########   ##     ##    ######### ## ### ##  ##  ##       */
+/* ##       ##     ## ##    ##  ######### ##   ##    ##     ##    ##     ## ##     ##  ##  ##       */
+/* ##       ##     ## ##    ##  ##     ## ##    ##   ##     ##    ##     ## ##     ##  ##  ##    ## */
+/* ########  #######   ######   ##     ## ##     ## ####    ##    ##     ## ##     ## ####  ######  */
+
+static bool log_iter_next(struct hdr_iter *iter)
+{
+    struct hdr_iter_log* logarithmic = &iter->specifics.log;
+
+    logarithmic->count_added_in_this_iteration_step = 0;
+
+    if (has_next(iter) ||
+        next_value_greater_than_reporting_level_upper_bound(
+            iter, logarithmic->next_value_reporting_level_lowest_equivalent))
+    {
+        do
+        {
+            if (iter->value >= logarithmic->next_value_reporting_level_lowest_equivalent)
+            {
+                update_iterated_values(iter, logarithmic->next_value_reporting_level);
+
+                logarithmic->next_value_reporting_level *= (int64_t)logarithmic->log_base;
+                logarithmic->next_value_reporting_level_lowest_equivalent = lowest_equivalent_value(iter->h, logarithmic->next_value_reporting_level);
+
+                return true;
+            }
+
+            if (!move_next(iter))
+            {
+                return true;
+            }
+
+            logarithmic->count_added_in_this_iteration_step += iter->count;
+        }
+        while (true);
+    }
+
+    return false;
+}
+
+void hdr_iter_log_init(
+        struct hdr_iter* iter,
+        const struct hdr_histogram* h,
+        int64_t value_units_first_bucket,
+        double log_base)
+{
+    hdr_iter_init(iter, h);
+    iter->specifics.log.count_added_in_this_iteration_step = 0;
+    iter->specifics.log.log_base = log_base;
+    iter->specifics.log.next_value_reporting_level = value_units_first_bucket;
+    iter->specifics.log.next_value_reporting_level_lowest_equivalent = lowest_equivalent_value(h, value_units_first_bucket);
+
+    iter->_next_fp = log_iter_next;
+}
+
+/* Printing. */
+
+static const char* format_head_string(format_type format)
+{
+    switch (format)
+    {
+        case CSV:
+            return "%s,%s,%s,%s\n";
+        case CLASSIC:
+        default:
+            return "%12s %12s %12s %12s\n\n";
+    }
+}
+
+static const char CLASSIC_FOOTER[] =
+    "#[Mean    = %12.3f, StdDeviation   = %12.3f]\n"
+    "#[Max     = %12.3f, Total count    = %12" PRIu64 "]\n"
+    "#[Buckets = %12d, SubBuckets     = %12d]\n";
+
+int hdr_percentiles_print(
+        struct hdr_histogram* h, FILE* stream, int32_t ticks_per_half_distance,
+        double value_scale, format_type format)
+{
+    char line_format[25];
+    const char* head_format;
+    int rc = 0;
+    struct hdr_iter iter;
+    struct hdr_iter_percentiles * percentiles;
+
+    format_line_string(line_format, 25, h->significant_figures, format);
+    head_format = format_head_string(format);
+
+    hdr_iter_percentile_init(&iter, h, ticks_per_half_distance);
+
+    if (fprintf(
+            stream, head_format,
+            "Value", "Percentile", "TotalCount", "1/(1-Percentile)") < 0)
+    {
+        rc = EIO;
+        goto cleanup;
+    }
+
+    percentiles = &iter.specifics.percentiles;
+    while (hdr_iter_next(&iter))
+    {
+        double  value               = iter.highest_equivalent_value / value_scale;
+        double  percentile          = percentiles->percentile / 100.0;
+        int64_t total_count         = iter.cumulative_count;
+        double  inverted_percentile = (1.0 / (1.0 - percentile));
+
+        if (fprintf(
+                stream, line_format, value, percentile, total_count, inverted_percentile) < 0)
+        {
+            rc = EIO;
+            goto cleanup;
+        }
+    }
+
+    if (CLASSIC == format)
+    {
+        double mean   = hdr_mean(h)   / value_scale;
+        double stddev = hdr_stddev(h) / value_scale;
+        double max    = hdr_max(h)    / value_scale;
+
+        if (fprintf(
+                stream, CLASSIC_FOOTER,  mean, stddev, max,
+                h->total_count, h->bucket_count, h->sub_bucket_count) < 0)
+        {
+            rc = EIO;
+            goto cleanup;
+        }
+    }
+
+    cleanup:
+    return rc;
+}

--- a/hdr_histogram.h
+++ b/hdr_histogram.h
@@ -1,0 +1,508 @@
+/**
+ * hdr_histogram.h
+ * Written by Michael Barker and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * The source for the hdr_histogram utilises a few C99 constructs, specifically
+ * the use of stdint/stdbool and inline variable declaration.
+ */
+
+#ifndef HDR_HISTOGRAM_H
+#define HDR_HISTOGRAM_H 1
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+typedef struct hdr_histogram
+{
+    int64_t lowest_discernible_value;
+    int64_t highest_trackable_value;
+    int32_t unit_magnitude;
+    int32_t significant_figures;
+    int32_t sub_bucket_half_count_magnitude;
+    int32_t sub_bucket_half_count;
+    int64_t sub_bucket_mask;
+    int32_t sub_bucket_count;
+    int32_t bucket_count;
+    int64_t min_value;
+    int64_t max_value;
+    int32_t normalizing_index_offset;
+    double conversion_ratio;
+    int32_t counts_len;
+    int64_t total_count;
+    int64_t* counts;
+} hdr_histogram_t;
+
+/**
+ * Allocate the memory and initialise the hdr_histogram.
+ *
+ * Due to the size of the histogram being the result of some reasonably
+ * involved math on the input parameters this function it is tricky to stack allocate.
+ * The histogram should be released with hdr_close
+ *
+ * @param lowest_discernible_value The smallest possible value that is distinguishable from 0.
+ * Must be a positive integer that is >= 1. May be internally rounded down to nearest power of 2.
+ * @param highest_trackable_value The largest possible value to be put into the
+ * histogram.
+ * @param significant_figures The level of precision for this histogram, i.e. the number
+ * of figures in a decimal number that will be maintained.  E.g. a value of 3 will mean
+ * the results from the histogram will be accurate up to the first three digits.  Must
+ * be a value between 1 and 5 (inclusive).
+ * @param result Output parameter to capture allocated histogram.
+ * @return 0 on success, EINVAL if lowest_discernible_value is < 1 or the
+ * significant_figure value is outside of the allowed range, ENOMEM if malloc
+ * failed.
+ */
+int hdr_init(
+    int64_t lowest_discernible_value,
+    int64_t highest_trackable_value,
+    int significant_figures,
+    struct hdr_histogram** result);
+
+/**
+ * Free the memory and close the hdr_histogram.
+ *
+ * @param h The histogram you want to close.
+ */
+void hdr_close(struct hdr_histogram* h);
+
+/**
+ * Allocate the memory and initialise the hdr_histogram.  This is the equivalent of calling
+ * hdr_init(1, highest_trackable_value, significant_figures, result);
+ *
+ * @deprecated use hdr_init.
+ */
+int hdr_alloc(int64_t highest_trackable_value, int significant_figures, struct hdr_histogram** result);
+
+
+/**
+ * Reset a histogram to zero - empty out a histogram and re-initialise it
+ *
+ * If you want to re-use an existing histogram, but reset everything back to zero, this
+ * is the routine to use.
+ *
+ * @param h The histogram you want to reset to empty.
+ *
+ */
+void hdr_reset(struct hdr_histogram* h);
+
+/**
+ * Get the memory size of the hdr_histogram.
+ *
+ * @param h "This" pointer
+ * @return The amount of memory used by the hdr_histogram in bytes
+ */
+size_t hdr_get_memory_size(struct hdr_histogram* h);
+
+/**
+ * Records a value in the histogram, will round this value of to a precision at or better
+ * than the significant_figure specified at construction time.
+ *
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @return false if the value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_value(struct hdr_histogram* h, int64_t value);
+
+/**
+ * Records a value in the histogram, will round this value of to a precision at or better
+ * than the significant_figure specified at construction time.
+ *
+ * Will record this value atomically, however the whole structure may appear inconsistent
+ * when read concurrently with this update.  Do NOT mix calls to this method with calls
+ * to non-atomic updates.
+ *
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @return false if the value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_value_atomic(struct hdr_histogram* h, int64_t value);
+
+/**
+ * Records count values in the histogram, will round this value of to a
+ * precision at or better than the significant_figure specified at construction
+ * time.
+ *
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @param count Number of 'value's to add to the histogram
+ * @return false if any value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_values(struct hdr_histogram* h, int64_t value, int64_t count);
+
+/**
+ * Records count values in the histogram, will round this value of to a
+ * precision at or better than the significant_figure specified at construction
+ * time.
+ *
+ * Will record this value atomically, however the whole structure may appear inconsistent
+ * when read concurrently with this update.  Do NOT mix calls to this method with calls
+ * to non-atomic updates.
+ *
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @param count Number of 'value's to add to the histogram
+ * @return false if any value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_values_atomic(struct hdr_histogram* h, int64_t value, int64_t count);
+
+/**
+ * Record a value in the histogram and backfill based on an expected interval.
+ *
+ * Records a value in the histogram, will round this value of to a precision at or better
+ * than the significant_figure specified at construction time.  This is specifically used
+ * for recording latency.  If the value is larger than the expected_interval then the
+ * latency recording system has experienced co-ordinated omission.  This method fills in the
+ * values that would have occurred had the client providing the load not been blocked.
+
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @param expected_interval The delay between recording values.
+ * @return false if the value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_corrected_value(struct hdr_histogram* h, int64_t value, int64_t expected_interval);
+
+/**
+ * Record a value in the histogram and backfill based on an expected interval.
+ *
+ * Records a value in the histogram, will round this value of to a precision at or better
+ * than the significant_figure specified at construction time.  This is specifically used
+ * for recording latency.  If the value is larger than the expected_interval then the
+ * latency recording system has experienced co-ordinated omission.  This method fills in the
+ * values that would have occurred had the client providing the load not been blocked.
+ *
+ * Will record this value atomically, however the whole structure may appear inconsistent
+ * when read concurrently with this update.  Do NOT mix calls to this method with calls
+ * to non-atomic updates.
+ *
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @param expected_interval The delay between recording values.
+ * @return false if the value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_corrected_value_atomic(struct hdr_histogram* h, int64_t value, int64_t expected_interval);
+
+/**
+ * Record a value in the histogram 'count' times.  Applies the same correcting logic
+ * as 'hdr_record_corrected_value'.
+ *
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @param count Number of 'value's to add to the histogram
+ * @param expected_interval The delay between recording values.
+ * @return false if the value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_corrected_values(struct hdr_histogram* h, int64_t value, int64_t count, int64_t expected_interval);
+
+/**
+ * Record a value in the histogram 'count' times.  Applies the same correcting logic
+ * as 'hdr_record_corrected_value'.
+ *
+ * Will record this value atomically, however the whole structure may appear inconsistent
+ * when read concurrently with this update.  Do NOT mix calls to this method with calls
+ * to non-atomic updates.
+ *
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @param count Number of 'value's to add to the histogram
+ * @param expected_interval The delay between recording values.
+ * @return false if the value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_corrected_values_atomic(struct hdr_histogram* h, int64_t value, int64_t count, int64_t expected_interval);
+
+/**
+ * Adds all of the values from 'from' to 'this' histogram.  Will return the
+ * number of values that are dropped when copying.  Values will be dropped
+ * if they around outside of h.lowest_discernible_value and
+ * h.highest_trackable_value.
+ *
+ * @param h "This" pointer
+ * @param from Histogram to copy values from.
+ * @return The number of values dropped when copying.
+ */
+int64_t hdr_add(struct hdr_histogram* h, const struct hdr_histogram* from);
+
+/**
+ * Adds all of the values from 'from' to 'this' histogram.  Will return the
+ * number of values that are dropped when copying.  Values will be dropped
+ * if they around outside of h.lowest_discernible_value and
+ * h.highest_trackable_value.
+ *
+ * @param h "This" pointer
+ * @param from Histogram to copy values from.
+ * @return The number of values dropped when copying.
+ */
+int64_t hdr_add_while_correcting_for_coordinated_omission(
+    struct hdr_histogram* h, struct hdr_histogram* from, int64_t expected_interval);
+
+/**
+ * Get minimum value from the histogram.  Will return 2^63-1 if the histogram
+ * is empty.
+ *
+ * @param h "This" pointer
+ */
+int64_t hdr_min(const struct hdr_histogram* h);
+
+/**
+ * Get maximum value from the histogram.  Will return 0 if the histogram
+ * is empty.
+ *
+ * @param h "This" pointer
+ */
+int64_t hdr_max(const struct hdr_histogram* h);
+
+/**
+ * Get the value at a specific percentile.
+ *
+ * @param h "This" pointer.
+ * @param percentile The percentile to get the value for
+ */
+int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile);
+
+/**
+ * Get the values at the given percentiles.
+ *
+ * @param h "This" pointer.
+ * @param percentiles The ordered percentiles array to get the values for.
+ * @param length Number of elements in the arrays.
+ * @param values Destination array containing the values at the given percentiles.
+ * The values array should be allocated by the caller.
+ * @return 0 on success, ENOMEM if the provided destination array is null.
+ */
+int hdr_value_at_percentiles(const struct hdr_histogram *h, const double *percentiles, int64_t *values, size_t length);
+
+/**
+ * Gets the standard deviation for the values in the histogram.
+ *
+ * @param h "This" pointer
+ * @return The standard deviation
+ */
+double hdr_stddev(const struct hdr_histogram* h);
+
+/**
+ * Gets the mean for the values in the histogram.
+ *
+ * @param h "This" pointer
+ * @return The mean
+ */
+double hdr_mean(const struct hdr_histogram* h);
+
+/**
+ * Determine if two values are equivalent with the histogram's resolution.
+ * Where "equivalent" means that value samples recorded for any two
+ * equivalent values are counted in a common total count.
+ *
+ * @param h "This" pointer
+ * @param a first value to compare
+ * @param b second value to compare
+ * @return 'true' if values are equivalent with the histogram's resolution.
+ */
+bool hdr_values_are_equivalent(const struct hdr_histogram* h, int64_t a, int64_t b);
+
+/**
+ * Get the lowest value that is equivalent to the given value within the histogram's resolution.
+ * Where "equivalent" means that value samples recorded for any two
+ * equivalent values are counted in a common total count.
+ *
+ * @param h "This" pointer
+ * @param value The given value
+ * @return The lowest value that is equivalent to the given value within the histogram's resolution.
+ */
+int64_t hdr_lowest_equivalent_value(const struct hdr_histogram* h, int64_t value);
+
+/**
+ * Get the count of recorded values at a specific value
+ * (to within the histogram resolution at the value level).
+ *
+ * @param h "This" pointer
+ * @param value The value for which to provide the recorded count
+ * @return The total count of values recorded in the histogram within the value range that is
+ * {@literal >=} lowestEquivalentValue(<i>value</i>) and {@literal <=} highestEquivalentValue(<i>value</i>)
+ */
+int64_t hdr_count_at_value(const struct hdr_histogram* h, int64_t value);
+
+int64_t hdr_count_at_index(const struct hdr_histogram* h, int32_t index);
+
+int64_t hdr_value_at_index(const struct hdr_histogram* h, int32_t index);
+
+struct hdr_iter_percentiles
+{
+    bool seen_last_value;
+    int32_t ticks_per_half_distance;
+    double percentile_to_iterate_to;
+    double percentile;
+};
+
+struct hdr_iter_recorded
+{
+    int64_t count_added_in_this_iteration_step;
+};
+
+struct hdr_iter_linear
+{
+    int64_t value_units_per_bucket;
+    int64_t count_added_in_this_iteration_step;
+    int64_t next_value_reporting_level;
+    int64_t next_value_reporting_level_lowest_equivalent;
+};
+
+struct hdr_iter_log
+{
+    double log_base;
+    int64_t count_added_in_this_iteration_step;
+    int64_t next_value_reporting_level;
+    int64_t next_value_reporting_level_lowest_equivalent;
+};
+
+/**
+ * The basic iterator.  This is a generic structure
+ * that supports all of the types of iteration.  Use
+ * the appropriate initialiser to get the desired
+ * iteration.
+ *
+ * @
+ */
+struct hdr_iter
+{
+    const struct hdr_histogram* h;
+    /** raw index into the counts array */
+    int32_t counts_index;
+    /** snapshot of the length at the time the iterator is created */
+    int64_t total_count;
+    /** value directly from array for the current counts_index */
+    int64_t count;
+    /** sum of all of the counts up to and including the count at this index */
+    int64_t cumulative_count;
+    /** The current value based on counts_index */
+    int64_t value;
+    int64_t highest_equivalent_value;
+    int64_t lowest_equivalent_value;
+    int64_t median_equivalent_value;
+    int64_t value_iterated_from;
+    int64_t value_iterated_to;
+
+    union
+    {
+        struct hdr_iter_percentiles percentiles;
+        struct hdr_iter_recorded recorded;
+        struct hdr_iter_linear linear;
+        struct hdr_iter_log log;
+    } specifics;
+
+    bool (* _next_fp)(struct hdr_iter* iter);
+
+};
+
+/**
+ * Initalises the basic iterator.
+ *
+ * @param itr 'This' pointer
+ * @param h The histogram to iterate over
+ */
+void hdr_iter_init(struct hdr_iter* iter, const struct hdr_histogram* h);
+
+/**
+ * Initialise the iterator for use with percentiles.
+ */
+void hdr_iter_percentile_init(struct hdr_iter* iter, const struct hdr_histogram* h, int32_t ticks_per_half_distance);
+
+/**
+ * Initialise the iterator for use with recorded values.
+ */
+void hdr_iter_recorded_init(struct hdr_iter* iter, const struct hdr_histogram* h);
+
+/**
+ * Initialise the iterator for use with linear values.
+ */
+void hdr_iter_linear_init(
+    struct hdr_iter* iter,
+    const struct hdr_histogram* h,
+    int64_t value_units_per_bucket);
+
+/**
+ * Initialise the iterator for use with logarithmic values
+ */
+void hdr_iter_log_init(
+    struct hdr_iter* iter,
+    const struct hdr_histogram* h,
+    int64_t value_units_first_bucket,
+    double log_base);
+
+/**
+ * Iterate to the next value for the iterator.  If there are no more values
+ * available return faluse.
+ *
+ * @param itr 'This' pointer
+ * @return 'false' if there are no values remaining for this iterator.
+ */
+bool hdr_iter_next(struct hdr_iter* iter);
+
+typedef enum
+{
+    CLASSIC,
+    CSV
+} format_type;
+
+/**
+ * Print out a percentile based histogram to the supplied stream.  Note that
+ * this call will not flush the FILE, this is left up to the user.
+ *
+ * @param h 'This' pointer
+ * @param stream The FILE to write the output to
+ * @param ticks_per_half_distance The number of iteration steps per half-distance to 100%
+ * @param value_scale Scale the output values by this amount
+ * @param format_type Format to use, e.g. CSV.
+ * @return 0 on success, error code on failure.  EIO if an error occurs writing
+ * the output.
+ */
+int hdr_percentiles_print(
+    struct hdr_histogram* h, FILE* stream, int32_t ticks_per_half_distance,
+    double value_scale, format_type format);
+
+/**
+* Internal allocation methods, used by hdr_dbl_histogram.
+*/
+struct hdr_histogram_bucket_config
+{
+    int64_t lowest_discernible_value;
+    int64_t highest_trackable_value;
+    int64_t unit_magnitude;
+    int64_t significant_figures;
+    int32_t sub_bucket_half_count_magnitude;
+    int32_t sub_bucket_half_count;
+    int64_t sub_bucket_mask;
+    int32_t sub_bucket_count;
+    int32_t bucket_count;
+    int32_t counts_len;
+};
+
+int hdr_calculate_bucket_config(
+    int64_t lowest_discernible_value,
+    int64_t highest_trackable_value,
+    int significant_figures,
+    struct hdr_histogram_bucket_config* cfg);
+
+void hdr_init_preallocated(struct hdr_histogram* h, struct hdr_histogram_bucket_config* cfg);
+
+int64_t hdr_size_of_equivalent_value_range(const struct hdr_histogram* h, int64_t value);
+
+int64_t hdr_next_non_equivalent_value(const struct hdr_histogram* h, int64_t value);
+
+int64_t hdr_median_equivalent_value(const struct hdr_histogram* h, int64_t value);
+
+/**
+ * Used to reset counters after importing data manually into the histogram, used by the logging code
+ * and other custom serialisation tools.
+ */
+void hdr_reset_internal_counters(struct hdr_histogram* h);
+
+#endif

--- a/ipc.c
+++ b/ipc.c
@@ -475,6 +475,14 @@ preallocated_entries(int obj_type)
 		entries = sizeof(filebench_shm->shm_cvar_lib_info)
 						/ sizeof(cvar_library_info_t);
 		break;
+	case FILEBENCH_HDR_HISTOGRAM:
+		entries = sizeof(filebench_shm->shm_hdr_histogram)
+						/ sizeof(hdr_histogram_t);
+		break;
+	case FILEBENCH_HDR_COUNTS:
+		entries = sizeof(filebench_shm->shm_hdr_counts)
+						/ (sizeof(int64_t) * FILEBENCH_COUNTS_PER_HISTOGRAM);
+		break;
 	default:
 		entries = -1;
 		filebench_log(LOG_ERROR, "preallocated_entries: "
@@ -585,6 +593,18 @@ ipc_malloc(int obj_type)
 			sizeof(cvar_library_info_t));
 		(void) ipc_mutex_unlock(&filebench_shm->shm_malloc_lock);
 		return ((char *)&filebench_shm->shm_cvar_lib_info[i]);
+
+	case FILEBENCH_HDR_HISTOGRAM:
+		(void) memset((char *)&filebench_shm->shm_hdr_histogram[i], 0,
+			sizeof(hdr_histogram_t));
+		(void) ipc_mutex_unlock(&filebench_shm->shm_malloc_lock);
+		return ((char *)&filebench_shm->shm_hdr_histogram[i]);
+
+	case FILEBENCH_HDR_COUNTS:
+		(void) memset((char *)&filebench_shm->shm_hdr_counts[i], 0,
+			sizeof(int64_t) * FILEBENCH_COUNTS_PER_HISTOGRAM);
+		(void) ipc_mutex_unlock(&filebench_shm->shm_malloc_lock);
+		return ((char *)&filebench_shm->shm_hdr_counts[i]);
 	}
 
 	filebench_log(LOG_ERROR, "Attempt to ipc_malloc unknown object type (%d)!",
@@ -662,6 +682,16 @@ ipc_free(int type, char *addr)
 	case FILEBENCH_CVAR_LIB_INFO:
 		base = (caddr_t)&filebench_shm->shm_cvar_lib_info[0];
 		size = sizeof(cvar_library_info_t);
+		break;
+
+	case FILEBENCH_HDR_HISTOGRAM:
+		base = (caddr_t)&filebench_shm->shm_hdr_histogram[0];
+		size = sizeof(hdr_histogram_t);
+		break;
+
+	case FILEBENCH_HDR_COUNTS:
+		base = (caddr_t)&filebench_shm->shm_hdr_counts[0];
+		size = sizeof(int64_t) * FILEBENCH_COUNTS_PER_HISTOGRAM;
 		break;
 	}
 

--- a/ipc.h
+++ b/ipc.h
@@ -65,7 +65,9 @@
 #define	FILEBENCH_RANDDIST		7
 #define FILEBENCH_CVAR			8
 #define FILEBENCH_CVAR_LIB_INFO		9
-#define	FILEBENCH_MAXTYPE		(FILEBENCH_CVAR_LIB_INFO + 1)
+#define FILEBENCH_HDR_HISTOGRAM		10
+#define FILEBENCH_HDR_COUNTS		11
+#define	FILEBENCH_MAXTYPE		(FILEBENCH_HDR_COUNTS + 1)
 
 /*
  * The values below are selected by intuition: these limits
@@ -88,6 +90,9 @@
 #define	FILEBENCH_NRANDDISTS		(16)
 #define FILEBENCH_NCVARS		(16)
 #define FILEBENCH_NCVAR_LIB_INFO	(32)
+#define FILEBENCH_NHDR_HISTOGRAM	(FILEBENCH_NFLOWOPS)
+/* 2560 is for hdr(1~60e3,2) */
+#define FILEBENCH_COUNTS_PER_HISTOGRAM	(2560)
 #define	FILEBENCH_MAXBITMAP		FILEBENCH_NFILESETENTRIES
 
 /* these below are not regular pools and are allocated separately from ipc_malloc() */
@@ -240,6 +245,8 @@ typedef struct filebench_shm {
 	randdist_t	shm_randdist[FILEBENCH_NRANDDISTS];
 	cvar_t		shm_cvar[FILEBENCH_NCVARS];
 	cvar_library_info_t shm_cvar_lib_info[FILEBENCH_NCVAR_LIB_INFO];
+	hdr_histogram_t	shm_hdr_histogram[FILEBENCH_NHDR_HISTOGRAM];
+	int64_t		shm_hdr_counts[FILEBENCH_NHDR_HISTOGRAM * 2][FILEBENCH_COUNTS_PER_HISTOGRAM];
 
 	/* these below are not regular pools and are allocated separately from ipc_malloc() */
 	char		shm_strings[FILEBENCH_STRINGMEMORY];

--- a/ipc.h
+++ b/ipc.h
@@ -90,7 +90,8 @@
 #define	FILEBENCH_NRANDDISTS		(16)
 #define FILEBENCH_NCVARS		(16)
 #define FILEBENCH_NCVAR_LIB_INFO	(32)
-#define FILEBENCH_NHDR_HISTOGRAM	(FILEBENCH_NFLOWOPS)
+/* one flowop needs at most one hdr_histogram, the extra 2 is for global statistics */
+#define FILEBENCH_NHDR_HISTOGRAM	(FILEBENCH_NFLOWOPS + 2)
 /* 2560 is for hdr(1~60e3,2) */
 #define FILEBENCH_COUNTS_PER_HISTOGRAM	(2560)
 #define	FILEBENCH_MAXBITMAP		FILEBENCH_NFILESETENTRIES
@@ -246,7 +247,7 @@ typedef struct filebench_shm {
 	cvar_t		shm_cvar[FILEBENCH_NCVARS];
 	cvar_library_info_t shm_cvar_lib_info[FILEBENCH_NCVAR_LIB_INFO];
 	hdr_histogram_t	shm_hdr_histogram[FILEBENCH_NHDR_HISTOGRAM];
-	int64_t		shm_hdr_counts[FILEBENCH_NHDR_HISTOGRAM * 2][FILEBENCH_COUNTS_PER_HISTOGRAM];
+	int64_t		shm_hdr_counts[FILEBENCH_NHDR_HISTOGRAM][FILEBENCH_COUNTS_PER_HISTOGRAM];
 
 	/* these below are not regular pools and are allocated separately from ipc_malloc() */
 	char		shm_strings[FILEBENCH_STRINGMEMORY];

--- a/stats.c
+++ b/stats.c
@@ -116,8 +116,8 @@ stats_snap(void)
 	(void) memset(globalstats, 0, FLOW_TYPES * sizeof(struct flowstats));
 	globalstats->fs_stime = orig_starttime;
 	globalstats->fs_etime = gethrtime();
-	global_read_hdr_histogram = flowop_hdr_init();
-	global_write_hdr_histogram = flowop_hdr_init();
+	global_read_hdr_histogram = fb_hdr_init();
+	global_write_hdr_histogram = fb_hdr_init();
 
 	total_time_sec = (globalstats->fs_etime -
 			globalstats->fs_stime) / SEC2NS_FLOAT;
@@ -147,8 +147,11 @@ stats_snap(void)
 		/* Roll up per-flowop into global stats */
 		stats_add(&globalstats[flowop->fo_type], &flowop->fo_stats);
 		stats_add(&globalstats[FLOW_TYPE_GLOBAL], &flowop->fo_stats);
-		hdr_add(global_read_hdr_histogram, flowop->fo_read_hdr_histogram);
-		hdr_add(global_write_hdr_histogram, flowop->fo_write_hdr_histogram);
+		if (flowop->fo_attrs & FLOW_ATTR_READ) {
+			hdr_add(global_read_hdr_histogram, flowop->fo_hdr_histogram);
+		} else if (flowop->fo_attrs & FLOW_ATTR_WRITE) {
+			hdr_add(global_write_hdr_histogram, flowop->fo_hdr_histogram);
+		}
 
 		flowop_master = flowop_find_one(flowop->fo_name, FLOW_MASTER);
 		if (flowop_master) {

--- a/vars.c
+++ b/vars.c
@@ -417,7 +417,7 @@ var_find_alloc(char *name)
 }
 
 int
-var_assign_boolean(char *name, boolean_t bool)
+var_assign_boolean(char *name, boolean_t boolvar)
 {
 	var_t *var;
 
@@ -427,7 +427,7 @@ var_assign_boolean(char *name, boolean_t bool)
 		return -1;
 	}
 
-	VAR_SET_BOOL(var, bool);
+	VAR_SET_BOOL(var, boolvar);
 
 	return 0;
 }
@@ -786,7 +786,7 @@ var_lvar_assign_var(char *name, char *src_name)
 }
 
 var_t *
-var_lvar_assign_boolean(char *name, boolean_t bool)
+var_lvar_assign_boolean(char *name, boolean_t boolvar)
 {
 	var_t *var;
 
@@ -797,7 +797,7 @@ var_lvar_assign_boolean(char *name, boolean_t bool)
 		return NULL;
 	}
 
-	VAR_SET_BOOL(var, bool);
+	VAR_SET_BOOL(var, boolvar);
 
 	return var;
 }

--- a/vars.h
+++ b/vars.h
@@ -160,13 +160,13 @@ typedef struct var {
 		(vp)->var_type = VAR_UNKNOWN; \
 	}
 
-avd_t avd_bool_alloc(boolean_t bool);
+avd_t avd_bool_alloc(boolean_t boolvar);
 avd_t avd_int_alloc(uint64_t integer);
 avd_t avd_dbl_alloc(double integer);
 avd_t avd_str_alloc(char *string);
 avd_t avd_var_alloc(char *varname);
 
-int var_assign_boolean(char *name, boolean_t bool);
+int var_assign_boolean(char *name, boolean_t boolvar);
 int var_assign_integer(char *name, uint64_t integer);
 int var_assign_double(char *name, double dbl);
 int var_assign_string(char *name, char *string);


### PR DESCRIPTION
Read/Write CDF/tail latency Support!

Add [hdr_histogram](https://github.com/HdrHistogram/HdrHistogram_c) for latency statistics

```bash
$echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
$sudo ./filebench -f workloads/oltp.f | tee log
Filebench Version 1.5-alpha3
0.000: Allocated 827MB of shared memory
0.001: OLTP Version 3.0  personality successfully loaded
0.001: Populating and pre-allocating filesets
0.002: logfile populated: 1 files, avg. dir. width = 1024, avg. dir. depth = 0.0, 0 leafdirs, 10.000MB total size
0.002: Reusing existing logfile tree
0.002: Pre-allocating files in logfile tree
0.002: datafiles populated: 10 files, avg. dir. width = 1024, avg. dir. depth = 0.3, 0 leafdirs, 100.000MB total size
0.002: Reusing existing datafiles tree
0.002: Pre-allocating files in datafiles tree
0.002: Waiting for pre-allocation to finish (in case of a parallel pre-allocation)
0.002: Population and pre-allocation of filesets completed
0.002: Starting 200 shadow instances
0.112: Starting 10 dbwr instances
0.118: Starting 1 lgwr instances
1.121: Running...
61.130: Run took 60 seconds...
61.147: Per-Operation Breakdown
random-rate          0ops        0ops/s   0.0mb/s    0.000ms/op [0.000ms - 0.000ms]
shadow-post-dbwr     315000ops     5249ops/s   0.0mb/s   36.712ms/op [0.013ms - 312.173ms]
shadow-post-lg       315200ops     5253ops/s   0.0mb/s    0.093ms/op [0.001ms - 13.822ms]
shadowhog            315200ops     5253ops/s   0.0mb/s    0.375ms/op [0.117ms - 18.196ms]
shadowread           340800ops     5679ops/s  10.3mb/s    0.071ms/op [0.001ms - 71.962ms]
dbwr-aiowait         3131ops       52ops/s   0.0mb/s    0.723ms/op [0.004ms - 16.044ms]
dbwr-block           3141ops       52ops/s   0.0mb/s    4.842ms/op [0.003ms - 124.242ms]
dbwr-hog             3141ops       52ops/s   0.0mb/s    0.020ms/op [0.005ms - 14.331ms]
dbwrite-a            315380ops     5256ops/s  10.2mb/s    0.006ms/op [0.001ms - 43.745ms]
lg-block             98ops        2ops/s   0.0mb/s  608.461ms/op [34.055ms - 981.712ms]
lg-aiowait           99ops        2ops/s   0.0mb/s    0.001ms/op [0.000ms - 0.002ms]
lg-write             100ops        2ops/s   0.4mb/s    0.012ms/op [0.001ms - 0.088ms]
61.147: IO Summary: 659510 ops 10990.768 ops/s 5679/5257 rd/wr  20.9mb/s 0.043ms/op

-------------------------------------------------------
Read Latency(us):

       Value   Percentile   TotalCount 1/(1-Percentile)

        1.00     0.000000          681         1.00
        3.00     0.100000       139950         1.11
        3.00     0.200000       139950         1.25
        3.00     0.300000       139950         1.43
        3.00     0.400000       139950         1.67
        4.00     0.500000       227487         2.00
        4.00     0.550000       227487         2.22
        4.00     0.600000       227487         2.50
        4.00     0.650000       227487         2.86
        5.00     0.700000       273162         3.33
        5.00     0.750000       273162         4.00
        5.00     0.775000       273162         4.44
        5.00     0.800000       273162         5.00
        6.00     0.825000       292660         5.71
        6.00     0.850000       292660         6.67
        7.00     0.875000       301783         8.00
        8.00     0.887500       306787         8.89
        8.00     0.900000       306787        10.00
       10.00     0.912500       313121        11.43
       11.00     0.925000       315457        13.33
       14.00     0.937500       320835        16.00
       15.00     0.943750       322379        17.78
       17.00     0.950000       324893        20.00
       19.00     0.956250       326593        22.86
       22.00     0.962500       328218        26.67
       29.00     0.968750       330323        32.00
       35.00     0.971875       331322        35.56
       44.00     0.975000       332346        40.00
       57.00     0.978125       333371        45.71
       72.00     0.981250       334424        53.33
       93.00     0.984375       335488        64.00
      105.00     0.985938       336009        71.11
      123.00     0.987500       336557        80.00
      147.00     0.989062       337091        91.43
      177.00     0.990625       337609       106.67
      228.00     0.992188       338143       128.00
      273.00     0.992969       338406       142.22
      341.00     0.993750       338670       160.00
      497.00     0.994531       338937       182.86
     1095.00     0.995313       339203       213.33
     2751.00     0.996094       339469       256.00
     3503.00     0.996484       339602       284.44
     4959.00     0.996875       339737       320.00
     6911.00     0.997266       339870       365.71
     8511.00     0.997656       340010       426.67
     9855.00     0.998047       340140       512.00
    10815.00     0.998242       340202       568.89
    11775.00     0.998437       340271       640.00
    13823.00     0.998633       340336       731.43
    19839.00     0.998828       340401       853.33
    26623.00     0.999023       340468      1024.00
    28415.00     0.999121       340503      1137.78
    30463.00     0.999219       340535      1280.00
    31615.00     0.999316       340568      1462.86
    33791.00     0.999414       340603      1706.67
    35071.00     0.999512       340638      2048.00
    35583.00     0.999561       340652      2275.56
    36351.00     0.999609       340670      2560.00
    38399.00     0.999658       340684      2925.71
    39423.00     0.999707       340706      3413.33
    39935.00     0.999756       340719      4096.00
    40959.00     0.999780       340726      4551.11
    42239.00     0.999805       340735      5120.00
    43519.00     0.999829       340744      5851.43
    44031.00     0.999854       340752      6826.67
    46335.00     0.999878       340759      8192.00
    47103.00     0.999890       340764      9102.22
    47359.00     0.999902       340767     10240.00
    47871.00     0.999915       340771     11702.86
    50943.00     0.999927       340776     13653.33
    51711.00     0.999939       340781     16384.00
    54271.00     0.999945       340783     18204.44
    54783.00     0.999951       340784     20480.00
    55039.00     0.999957       340788     23405.71
    55039.00     0.999963       340788     27306.67
    55295.00     0.999969       340790     32768.00
    55807.00     0.999973       340792     36408.89
    55807.00     0.999976       340792     40960.00
    56063.00     0.999979       340793     46811.43
    58623.00     0.999982       340794     54613.33
    59135.00     0.999985       340795     65536.00
    59903.00     0.999986       340796     72817.78
    59903.00     0.999988       340796     81920.00
    60159.00     0.999989       340797     93622.86
    60159.00     0.999991       340797    109226.67
    61439.00     0.999992       340798    131072.00
    61439.00     0.999993       340798    145635.56
    61439.00     0.999994       340798    163840.00
    63231.00     0.999995       340799    187245.71
    63231.00     0.999995       340799    218453.33
    63231.00     0.999996       340799    262144.00
    63231.00     0.999997       340799    291271.11
    63231.00     0.999997       340799    327680.00
    72191.00     0.999997       340800    374491.43
    72191.00     1.000000       340800          inf
#[Mean    =       71.280, StdDeviation   =     1302.406]
#[Max     =    72191.000, Total count    =       340800]
#[Buckets =           19, SubBuckets     =          256]
#[p95     =           17, p99            =          165]
#[p99.9   =          165, p99.99         =        47359]

-------------------------------------------------------
Write Latency(us):

       Value   Percentile   TotalCount 1/(1-Percentile)

        0.00     0.000000        15848         1.00
        1.00     0.100000        60140         1.11
        2.00     0.200000       145580         1.25
        2.00     0.300000       145580         1.43
        2.00     0.400000       145580         1.67
        3.00     0.500000       227224         2.00
        3.00     0.550000       227224         2.22
        3.00     0.600000       227224         2.50
        3.00     0.650000       227224         2.86
        3.00     0.700000       227224         3.33
        4.00     0.750000       277500         4.00
        4.00     0.775000       277500         4.44
        4.00     0.800000       277500         5.00
        4.00     0.825000       277500         5.71
        4.00     0.850000       277500         6.67
        4.00     0.875000       277500         8.00
        5.00     0.887500       297352         8.89
        5.00     0.900000       297352        10.00
        5.00     0.912500       297352        11.43
        5.00     0.925000       297352        13.33
        5.00     0.937500       297352        16.00
        6.00     0.943750       302993        17.78
        6.00     0.950000       302993        20.00
        6.00     0.956250       302993        22.86
        7.00     0.962500       305246        26.67
        8.00     0.968750       306713        32.00
        8.00     0.971875       306713        35.56
        9.00     0.975000       307750        40.00
       10.00     0.978125       308599        45.71
       12.00     0.981250       310086        53.33
       13.00     0.984375       310796        64.00
       14.00     0.985938       311360        71.11
       15.00     0.987500       311800        80.00
       16.00     0.989062       312107        91.43
       18.00     0.990625       312564       106.67
       21.00     0.992188       313057       128.00
       23.00     0.992969       313330       142.22
       25.00     0.993750       313533       160.00
       28.00     0.994531       313802       182.86
       32.00     0.995313       314044       213.33
       37.00     0.996094       314280       256.00
       40.00     0.996484       314393       284.44
       43.00     0.996875       314496       320.00
       48.00     0.997266       314640       365.71
       52.00     0.997656       314750       426.67
       57.00     0.998047       314872       512.00
       60.00     0.998242       314945       568.89
       63.00     0.998437       314999       640.00
       66.00     0.998633       315057       731.43
       72.00     0.998828       315117       853.33
       78.00     0.999023       315174      1024.00
       81.00     0.999121       315208      1137.78
       87.00     0.999219       315235      1280.00
       94.00     0.999316       315268      1462.86
      101.00     0.999414       315297      1706.67
      110.00     0.999512       315327      2048.00
      117.00     0.999561       315343      2275.56
      125.00     0.999609       315358      2560.00
      136.00     0.999658       315373      2925.71
      162.00     0.999707       315388      3413.33
      192.00     0.999756       315403      4096.00
      215.00     0.999780       315411      4551.11
      289.00     0.999805       315419      5120.00
      363.00     0.999829       315427      5851.43
      477.00     0.999854       315434      6826.67
     1399.00     0.999878       315442      8192.00
     1791.00     0.999890       315446      9102.22
     3231.00     0.999902       315450     10240.00
    11263.00     0.999915       315454     11702.86
    12095.00     0.999927       315457     13653.33
    20863.00     0.999939       315461     16384.00
    33535.00     0.999945       315463     18204.44
    34559.00     0.999951       315467     20480.00
    34559.00     0.999957       315467     23405.71
    34815.00     0.999963       315469     27306.67
    35583.00     0.999969       315472     32768.00
    35583.00     0.999973       315472     36408.89
    35839.00     0.999976       315475     40960.00
    35839.00     0.999979       315475     46811.43
    35839.00     0.999982       315475     54613.33
    36095.00     0.999985       315476     65536.00
    36095.00     0.999986       315476     72817.78
    37119.00     0.999988       315477     81920.00
    37119.00     0.999989       315477     93622.86
    39935.00     0.999991       315478    109226.67
    39935.00     0.999992       315478    131072.00
    39935.00     0.999993       315478    145635.56
    42751.00     0.999994       315479    163840.00
    42751.00     0.999995       315479    187245.71
    42751.00     0.999995       315479    218453.33
    42751.00     0.999996       315479    262144.00
    42751.00     0.999997       315479    291271.11
    43775.00     0.999997       315480    327680.00
    43775.00     1.000000       315480          inf
#[Mean    =        5.870, StdDeviation   =      290.627]
#[Max     =    43775.000, Total count    =       315480]
#[Buckets =           19, SubBuckets     =          256]
#[p95     =            6, p99            =           17]
#[p99.9   =           78, p99.99         =         2239]
61.148: Shutting down processes
```