### PR TITLE
configure.ac: Improve C99 compatibility of HAVE_IOPRIO check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -370,7 +370,8 @@ AC_TRY_COMPILE([
 # check for I/O priority system calls
 AC_MSG_CHECKING(for I/O priority system calls)
 AC_TRY_COMPILE([
-	#include <syscall.h>],
+	#include <syscall.h>
+	#include <unistd.h>],
   	[(void)syscall(__NR_ioprio_set, 0, 0, 0);
 	],[
 	    AC_DEFINE(HAVE_IOPRIO, 1, [ Define if you have I/O priority syscalls. ])


### PR DESCRIPTION
Include <unistd.h> to obtain a declaration of the syscall function. Implicit function declarations are likely to be rejected by future compilers by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
