### PR TITLE
fb_localfs.c： fix memory leakage bug in fb_lfsflow_aiowait function

### DIFF
--- a/fb_localfs.c
+++ b/fb_localfs.c
@@ -265,13 +265,11 @@ aio_deallocate(flowop_t *flowop, struct aiocb64 *aiocb)
 
 	if (match == NULL)
 		return (FILEBENCH_ERROR);
-
 	/* Remove from the list */
 	if (previous)
 		previous->al_next = match->al_next;
 	else
 		flowop->fo_thread->tf_aiolist = match->al_next;
-
 	return (FILEBENCH_OK);
 }
 
@@ -429,6 +427,7 @@ fb_lfsflow_aiowait(threadflow_t *threadflow, flowop_t *flowop)
 
 #else
 
+		aiolist_t *al_prev = NULL;
 		for (ncompleted = 0, inprogress = 0,
 		    aio = flowop->fo_thread->tf_aiolist;
 		    ncompleted < todo && aio != NULL; aio = aio->al_next) {
@@ -453,7 +452,13 @@ fb_lfsflow_aiowait(threadflow_t *threadflow, flowop_t *flowop)
 				flowop_endop(threadflow, flowop, 0);
 				return (FILEBENCH_ERROR);
 			}
+			if (al_prev)
+                                free(al_prev);
+
+			al_prev = aio;
 		}
+		if (al_prev)
+                        free(al_prev);
 
 		uncompleted -= ncompleted;
 

--- a/fb_localfs.c
+++ b/fb_localfs.c
@@ -265,11 +265,13 @@ aio_deallocate(flowop_t *flowop, struct aiocb64 *aiocb)
 
 	if (match == NULL)
 		return (FILEBENCH_ERROR);
+
 	/* Remove from the list */
 	if (previous)
 		previous->al_next = match->al_next;
 	else
 		flowop->fo_thread->tf_aiolist = match->al_next;
+	
 	return (FILEBENCH_OK);
 }
 
@@ -454,7 +456,6 @@ fb_lfsflow_aiowait(threadflow_t *threadflow, flowop_t *flowop)
 			}
 			if (al_prev)
                                 free(al_prev);
-
 			al_prev = aio;
 		}
 		if (al_prev)


### PR DESCRIPTION
Filebench-1.5-alpha3 has memory leak when running oltp.f workload, fb_lfsflow_aiowrite function constantly allocates node, and  fb_lfsflow_aiowait function doesn't free the node space.